### PR TITLE
Security: Exclude .mcpregistry tokens from PyPI builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "claude-smalltalk"
-version = "1.2.1"
+version = "1.2.2"
 description = "MCP server for AI interaction with live Smalltalk images (Cuis and Squeak)"
 readme = "README.md"
 license = {text = "MIT"}
@@ -50,6 +50,9 @@ Repository = "https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk
 [project.scripts]
 claude-smalltalk = "claude_smalltalk:main"
 openai-smalltalk = "claude_smalltalk.openai_mcp:main"
+
+[tool.hatch.build.targets.sdist]
+exclude = [".mcpregistry*", "mcp-publisher"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["claude_smalltalk"]


### PR DESCRIPTION
Both `.mcpregistry_github_token` and `.mcpregistry_registry_token` were being included in PyPI sdist tarballs (1.2.0 and 1.2.1) despite being in `.gitignore`. Hatchling doesn't respect `.gitignore` for sdist builds.

**Changes:**
- Added `[tool.hatch.build.targets.sdist]` exclude for `.mcpregistry*` and `mcp-publisher`
- Version bump to 1.2.2

**After merge:**
1. `python3 -m build` and `twine upload` clean 1.2.2
2. Yank 1.2.0 and 1.2.1 on PyPI
3. Both leaked tokens already revoked by GitHub