### PR TITLE
Sync version numbers to 1.2.2

### DIFF
--- a/claude_smalltalk/__init__.py
+++ b/claude_smalltalk/__init__.py
@@ -1,6 +1,6 @@
 """Claude Smalltalk - MCP server for AI interaction with live Smalltalk images."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 from .mcp_server import run_server as main
 

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk",
     "source": "github"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "claude-smalltalk",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
server.json and claude_smalltalk/__init__.py were still showing 1.2.1 while pyproject.toml was bumped to 1.2.2 in PR #22.