### PR TITLE
Sync from Bitbucket: MCPServer v5→v7, class-side support, LLM tools, daemon mode

### DIFF
--- a/CLAWDBOT-SETUP.md
+++ b/CLAWDBOT-SETUP.md
@@ -52,12 +52,17 @@ cp ~/Squeak6.0-*/shared/SqueakV60.sources ~/
 Copy the skill to your Clawdbot skills directory:
 
 ```bash
-mkdir -p ~/clawd/skills/smalltalk
-cp clawdbot/SKILL.md ~/clawd/skills/smalltalk/
-cp clawdbot/smalltalk.py ~/clawd/skills/smalltalk/
-cp clawdbot/smalltalk-daemon.py ~/clawd/skills/smalltalk/
-chmod +x ~/clawd/skills/smalltalk/smalltalk.py
-chmod +x ~/clawd/skills/smalltalk/smalltalk-daemon.py
+mkdir -p ~/clawd/skills/smalltalk/clawdbot
+cp clawdbot/SKILL.md ~/clawd/skills/smalltalk/clawdbot/
+cp clawdbot/smalltalk.py ~/clawd/skills/smalltalk/clawdbot/
+cp clawdbot/smalltalk-daemon.py ~/clawd/skills/smalltalk/clawdbot/
+cp clawdbot/smalltalk-dev-daemon.py ~/clawd/skills/smalltalk/clawdbot/
+cp clawdbot/smalltalk_projects.py ~/clawd/skills/smalltalk/clawdbot/
+cp clawdbot/st ~/clawd/skills/smalltalk/clawdbot/
+chmod +x ~/clawd/skills/smalltalk/clawdbot/smalltalk.py
+chmod +x ~/clawd/skills/smalltalk/clawdbot/smalltalk-daemon.py
+chmod +x ~/clawd/skills/smalltalk/clawdbot/smalltalk-dev-daemon.py
+chmod +x ~/clawd/skills/smalltalk/clawdbot/st
 ```
 
 ## Step 6: Configure Paths (Optional)
@@ -74,15 +79,14 @@ Add to `~/.bashrc` or `~/.profile` to persist.
 ## Step 7: Verify Setup
 
 ```bash
-python3 ~/clawd/skills/smalltalk/smalltalk.py --check
+python3 ~/clawd/skills/smalltalk/clawdbot/smalltalk.py --check
 ```
 
 Expected output:
 ```
 🔍 Checking Clawdbot Smalltalk setup...
 
-ℹ️  Daemon not running (will use exec mode)
-   Start with: smalltalk-daemon.py start
+ℹ️  Daemon not running (will auto-start on first use)
 
 ✅ xvfb-run found
 ✅ VM found: /home/user/Squeak6.0-.../bin/squeak
@@ -90,55 +94,57 @@ Expected output:
 ✅ Sources file found: /home/user/SqueakV60.sources
 
 🔍 Checking MCPServer version...
-✅ MCPServer version: 2
+✅ MCPServer version: 7
 
 ✅ Setup looks good!
 ```
 
-**Note:** MCPServer version 2+ is required for `define-method` to work correctly in headless mode. If you see version 0 or 1, update your image by filing in `MCP-Server-Squeak.st`.
+**Note:** MCPServer version 7+ is required. If you see an older version, update your image by filing in the latest `MCP-Server-Squeak.st`.
 
 ## Step 8: Test
 
 ```bash
-python3 ~/clawd/skills/smalltalk/smalltalk.py evaluate "3 factorial"
+python3 ~/clawd/skills/smalltalk/clawdbot/smalltalk.py evaluate "3 factorial"
 # Should output: 6
 ```
 
-## Exec Mode vs Daemon Mode
+## Daemon Mode
 
-The skill supports two operating modes:
+The skill runs a persistent Squeak VM via a daemon process. The daemon starts automatically on first use — no manual startup required.
 
-### Exec Mode (Default)
+### How It Works
 
-- Spawns a fresh Squeak VM for each command
-- State does **not** persist between calls
-- Best for: read-only queries (browse, evaluate, hierarchy, etc.)
+1. You run a command via `smalltalk.py` (e.g., `evaluate "3 + 4"`)
+2. `smalltalk.py` checks for a running daemon via Unix socket
+3. If no daemon is running, it starts one automatically
+4. Commands are sent over the Unix socket to the daemon
+5. The daemon relays them to the Squeak VM via stdio/JSON-RPC
 
-### Daemon Mode (Persistent State)
+### Daemon Startup Sequence
 
-- Keeps a single Squeak VM running
-- State **persists** across calls (classes/methods you define stay in memory)
-- Best for: development sessions where you define classes and methods
+The daemon (`smalltalk-daemon.py`) launches Squeak under `xvfb-run` with environment variables:
 
-### Starting the Daemon
+| Variable | Purpose |
+|----------|---------|
+| `SMALLTALK_MCP_DAEMON=1` | Triggers daemon mode in `MCPServer startUp:` |
+| `SMALLTALK_DEV_MODE=1` | Enables save tools and preserves changes file |
+| `SMALLTALK_CHANGES_PATH=<path>` | Where to write the changes file in dev mode |
 
-Use `nohup` to prevent the daemon from being killed by process wrappers:
+The image's `MCPServer startUp:` method detects `SMALLTALK_MCP_DAEMON=1` and calls `startDaemon`, which runs the MCP server **inline** during `processStartUpList:` — before Morphic's `wakeUpTopWindow` blocks under `xvfb-run`.
 
-```bash
-nohup python3 ~/clawd/skills/smalltalk/smalltalk-daemon.py start > /tmp/smalltalk-daemon.log 2>&1 &
+### Socket Path
+
+The daemon uses a user-isolated Unix socket:
+```
+/tmp/smalltalk-daemon-$USER.sock
 ```
 
-Verify it's running:
+This allows multiple users on the same machine to run independent daemons.
+
+### Manual Daemon Commands
 
 ```bash
-python3 ~/clawd/skills/smalltalk/smalltalk.py --daemon-status
-# Should output: ✅ Daemon running (fast mode)
-```
-
-### Daemon Commands
-
-```bash
-smalltalk-daemon.py start    # Start daemon (foreground by default)
+smalltalk-daemon.py start    # Start daemon (foreground)
 smalltalk-daemon.py stop     # Stop running daemon
 smalltalk-daemon.py status   # Check if daemon is running
 smalltalk-daemon.py restart  # Restart daemon
@@ -147,7 +153,7 @@ smalltalk-daemon.py restart  # Restart daemon
 ### Stopping the Daemon
 
 ```bash
-python3 ~/clawd/skills/smalltalk/smalltalk-daemon.py stop
+python3 ~/clawd/skills/smalltalk/clawdbot/smalltalk-daemon.py stop
 ```
 
 Or kill all related processes:
@@ -169,7 +175,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 %h/clawd/skills/smalltalk/smalltalk-daemon.py start
+ExecStart=/usr/bin/python3 %h/clawd/skills/smalltalk/clawdbot/smalltalk-daemon.py start
 Restart=on-failure
 RestartSec=5
 
@@ -185,13 +191,48 @@ systemctl --user enable smalltalk-daemon
 systemctl --user start smalltalk-daemon
 ```
 
+## Dev Mode vs Playground Mode
+
+### Playground Mode (Default)
+
+- Changes file redirected to `/dev/null`
+- `smalltalk_save_image` and `smalltalk_save_as_new_version` return errors
+- Safe for experimentation — nothing persists to disk
+
+### Dev Mode (`SMALLTALK_DEV_MODE=1`)
+
+- Changes file is preserved (written to `SMALLTALK_CHANGES_PATH`)
+- `smalltalk_save_image` saves the image in place
+- `smalltalk_save_as_new_version` saves with an incremented version number
+- Uses `headlessSave` which calls `snapshotPrimitive` directly, avoiding Morphic UI operations that would hang under `xvfb-run`
+
 ## Usage with Clawdbot
 
 Once set up, ask Clawdbot things like:
 - "Evaluate `Date today` in Smalltalk"
 - "Browse the OrderedCollection class"
 - "Show me the source of String>>asUppercase"
+- "Show me the class-side method MCPServer class>>version"
 - "What are the subclasses of Collection?"
+
+### LLM-Powered CLI Tools (JMM-510/JMM-511)
+
+The skill includes LLM-powered analysis tools that require `OPENAI_API_KEY`:
+
+```bash
+# Explain a method (instance or class side)
+smalltalk.py explain-method OrderedCollection sort: --detail=detailed
+smalltalk.py explain-method "MCPServer class" startUp: --class-side
+
+# Audit a method's comment against its implementation
+smalltalk.py audit-comment OrderedCollection removeFirst
+smalltalk.py audit-comment MCPServer version --class-side
+
+# Audit all methods in a class (instance + class side)
+smalltalk.py audit-class MCPTransport
+```
+
+Options for explain: `--detail=brief|detailed|step-by-step`, `--audience=beginner|experienced`
 
 ## Troubleshooting
 
@@ -213,8 +254,8 @@ chmod +x ~/Squeak6.0-*/bin/squeak
 
 ### No response from MCP server
 - Ensure image was saved after `Smalltalk addToStartUpList: MCPServer`
-- Check that `--mcp` flag triggers the server
 - Verify xvfb is working: `xvfb-run -a echo "works"`
+- Check daemon logs: `cat /tmp/smalltalk-daemon-$USER.log`
 
 ### Debugging a hung system with screenshots
 
@@ -226,7 +267,7 @@ export DISPLAY=:99
 Xvfb :99 -screen 0 1024x768x24 &
 
 # Start Squeak
-/path/to/squeak ~/ClaudeSqueak.image --mcp &
+/path/to/squeak ~/ClaudeSqueak.image &
 
 # Wait a few seconds, then capture screenshot
 sleep 5
@@ -251,7 +292,7 @@ kill -USR1 <PID>
 
 If Squeak was started with output redirected to a log file:
 ```bash
-/path/to/squeak image.image --mcp > /tmp/squeak.log 2>&1 &
+/path/to/squeak image.image > /tmp/squeak.log 2>&1 &
 ```
 
 The stack trace will appear in `/tmp/squeak.log`, showing what each process is doing:
@@ -277,35 +318,34 @@ Then log out and back in.
 
 ## Architecture
 
-### Exec Mode (Fresh VM per call)
-
 ```
 Clawdbot
     │
     ▼ exec
-smalltalk.py
+smalltalk.py (auto-starts daemon if needed)
     │
-    ▼ xvfb-run + stdio
-Squeak VM + ClaudeSqueak.image  (spawned, then exits)
-    │
-    ▼ MCP JSON-RPC
-MCPServer (12 tools)
-```
-
-### Daemon Mode (Persistent VM)
-
-```
-Clawdbot
-    │
-    ▼ exec
-smalltalk.py
-    │
-    ▼ Unix socket (/tmp/smalltalk-daemon.sock)
+    ▼ Unix socket (/tmp/smalltalk-daemon-$USER.sock)
 smalltalk-daemon.py
+    │  Sets env vars: SMALLTALK_MCP_DAEMON=1
+    │                 SMALLTALK_DEV_MODE=1 (optional)
+    │                 SMALLTALK_CHANGES_PATH=... (optional)
     │
-    ▼ stdio (persistent connection)
-Squeak VM + ClaudeSqueak.image  (long-running)
+    ▼ xvfb-run + stdio (persistent connection)
+Squeak VM + ClaudeSqueak.image
+    │  MCPServer startUp: detects SMALLTALK_MCP_DAEMON=1
+    │  → calls startDaemon (inline, before Morphic blocks)
     │
     ▼ MCP JSON-RPC
-MCPServer (12 tools)
+MCPServer (14 tools, v7)
 ```
+
+### Skill Files
+
+| File | Purpose |
+|------|---------|
+| `smalltalk.py` | Entry point — routes commands to daemon, auto-starts if needed |
+| `smalltalk-daemon.py` | Daemon — manages persistent Squeak VM, Unix socket server |
+| `smalltalk-dev-daemon.py` | Dev mode variant of the daemon |
+| `smalltalk_projects.py` | Project management utilities |
+| `st` | CLI wrapper for quick Smalltalk interaction |
+| `SKILL.md` | Clawdbot skill definition |

--- a/MCP-Server-Squeak.st
+++ b/MCP-Server-Squeak.st
@@ -394,17 +394,22 @@ toolDefListClasses
 toolDefMethodSource
 	^ (Dictionary new)
 		at: 'name' put: 'smalltalk_method_source';
-		at: 'description' put: 'Get the source code of a specific method.';
+		at: 'description' put: 'Get the source code of a specific method. Use side=class for class-side methods, or append " class" to className.';
 		at: 'inputSchema' put: ((Dictionary new)
 			at: 'type' put: 'object';
 			at: 'properties' put: ((Dictionary new)
 				at: 'className' put: ((Dictionary new)
 					at: 'type' put: 'string';
-					at: 'description' put: 'Name of the class';
+					at: 'description' put: 'Name of the class (append " class" for class-side, e.g. "MCPServer class")';
 					yourself);
 				at: 'selector' put: ((Dictionary new)
 					at: 'type' put: 'string';
 					at: 'description' put: 'Method selector';
+					yourself);
+				at: 'side' put: ((Dictionary new)
+					at: 'type' put: 'string';
+					at: 'enum' put: #('instance' 'class');
+					at: 'description' put: 'Which side to look up: instance (default) or class';
 					yourself);
 				yourself);
 			at: 'required' put: #('className' 'selector');
@@ -428,6 +433,28 @@ toolDefSubclasses
 			yourself);
 		yourself.! !
 
+!MCPServer methodsFor: 'tool definitions' stamp: 'jmm 1/29/2026 20:20'!
+toolDefSaveImage
+	^ (Dictionary new)
+		at: 'name' put: 'smalltalk_save_image';
+		at: 'description' put: 'Save the current image in place. Only available in dev mode.';
+		at: 'inputSchema' put: ((Dictionary new)
+			at: 'type' put: 'object';
+			at: 'properties' put: Dictionary new;
+			yourself);
+		yourself.! !
+
+!MCPServer methodsFor: 'tool definitions' stamp: 'jmm 1/29/2026 20:20'!
+toolDefSaveAsNewVersion
+	^ (Dictionary new)
+		at: 'name' put: 'smalltalk_save_as_new_version';
+		at: 'description' put: 'Save the image/changes using the next available version number. Only available in dev mode.';
+		at: 'inputSchema' put: ((Dictionary new)
+			at: 'type' put: 'object';
+			at: 'properties' put: Dictionary new;
+			yourself);
+		yourself.! !
+
 !MCPServer methodsFor: 'tool definitions' stamp: 'Claude 1/21/2026 12:00'!
 toolDefinitions
 	"Return all tool definitions for MCP tools/list"
@@ -443,7 +470,9 @@ toolDefinitions
 		self toolDefHierarchy.
 		self toolDefSubclasses.
 		self toolDefListCategories.
-		self toolDefClassesInCategory
+		self toolDefClassesInCategory.
+		self toolDefSaveImage.
+		self toolDefSaveAsNewVersion
 	}.! !
 
 !MCPServer methodsFor: 'tool dispatch' stamp: 'Claude 1/21/2026 12:00'!
@@ -461,11 +490,14 @@ executeTool: name arguments: args
 	name = 'smalltalk_subclasses' ifTrue: [ ^ self toolSubclasses: args ].
 	name = 'smalltalk_list_categories' ifTrue: [ ^ self toolListCategories: args ].
 	name = 'smalltalk_classes_in_category' ifTrue: [ ^ self toolClassesInCategory: args ].
+	name = 'smalltalk_save_image' ifTrue: [ ^ self toolSaveImage: args ].
+	name = 'smalltalk_save_as_new_version' ifTrue: [ ^ self toolSaveAsNewVersion: args ].
 	self error: 'Unknown tool: ', name.! !
 
 !MCPServer methodsFor: 'tool implementations' stamp: 'Claude 1/21/2026 12:00'!
 toolBrowse: args
-	"Browse a class - return metadata as JSON"
+	"Browse a class - return metadata as JSON.
+	 Includes both instance-side and class-side methods."
 	| className class result |
 	className := args at: 'className' ifAbsent: [ '' ].
 	className isEmpty ifTrue: [ self error: 'No className provided' ].
@@ -480,7 +512,8 @@ toolBrowse: args
 	result at: 'instanceVariables' put: class instVarNames asArray.
 	result at: 'classVariables' put: class classVarNames asArray.
 	result at: 'methods' put: class selectors asArray sorted.
-	result at: 'comment' put: (class comment ifNil: [ '' ]).
+	result at: 'classMethods' put: class class selectors asArray sorted.
+	result at: 'comment' put: ([ class comment ifNil: [ '' ] ] on: Error do: [ :e | '' ]).
 	^ Json render: result.! !
 
 !MCPServer methodsFor: 'tool implementations' stamp: 'Claude 1/21/2026 12:00'!
@@ -588,18 +621,39 @@ toolListClasses: args
 
 !MCPServer methodsFor: 'tool implementations' stamp: 'Claude 1/21/2026 12:00'!
 toolMethodSource: args
-	"Get source code of a method"
-	| className selector class method |
+	"Get source code of a method. Supports both instance and class side.
+	 Class side can be requested via side='class' parameter or by appending
+	 ' class' to className (e.g. 'MCPServer class')."
+	| className selector side class target method displayName |
 	className := args at: 'className' ifAbsent: [ '' ].
 	selector := args at: 'selector' ifAbsent: [ '' ].
+	side := args at: 'side' ifAbsent: [ 'instance' ].
 	className isEmpty ifTrue: [ self error: 'No className provided' ].
 	selector isEmpty ifTrue: [ self error: 'No selector provided' ].
+	
+	"Handle 'ClassName class' syntax in className"
+	(className endsWith: ' class') ifTrue: [
+		className := className copyFrom: 1 to: className size - 6.
+		side := 'class' ].
+	
 	class := Smalltalk at: className asSymbol ifAbsent: [
 		self error: 'Class not found: ', className ].
-	(class includesSelector: selector asSymbol) ifFalse: [
-		self error: 'Method not found: ', className, '>>', selector ].
-	method := class >> selector asSymbol.
-	^ method getSourceFromFile asString.! !
+	
+	target := side = 'class'
+		ifTrue: [ class class ]
+		ifFalse: [ class ].
+	displayName := side = 'class'
+		ifTrue: [ className, ' class' ]
+		ifFalse: [ className ].
+	
+	(target includesSelector: selector asSymbol) ifFalse: [
+		self error: 'Method not found: ', displayName, '>>', selector ].
+	method := target >> selector asSymbol.
+	"Try source file first, fall back to decompilation if .changes is unavailable
+	 (e.g. playground mode where changes → /dev/null)"
+	^ [ method getSourceFromFile asString ]
+		on: Error
+		do: [ :e | method decompileString ].! !
 
 !MCPServer methodsFor: 'tool implementations' stamp: 'Claude 1/21/2026 12:00'!
 toolSubclasses: args
@@ -612,38 +666,244 @@ toolSubclasses: args
 	names := (class subclasses collect: [ :c | c name ]) asArray sorted.
 	^ Json render: names.! !
 
-!MCPServer class methodsFor: 'system startup' stamp: 'Claude 1/21/2026 12:00'!
+!MCPServer methodsFor: 'tool implementations' stamp: 'jmm 1/29/2026 21:00'!
+toolSaveImage: args
+	"Save the current image in place. Only works in dev mode.
+	Uses headlessSave which skips Cursor/Morphic UI operations."
+	| changesFile |
+	changesFile := SourceFiles at: 2.
+	(changesFile isNil or: [ changesFile name = '/dev/null' ])
+		ifTrue: [ self error: 'Save is only available in dev mode. Start with --dev --image.' ].
+	self class headlessSave.
+	^ 'Image saved: ', Smalltalk imageName.! !
+
+!MCPServer methodsFor: 'tool implementations' stamp: 'jmm 1/29/2026 21:00'!
+toolSaveAsNewVersion: args
+	"Save image/changes as next version number. Only works in dev mode.
+	Uses headlessSaveAsNewVersion to avoid UI hangs under xvfb."
+	| changesFile |
+	changesFile := SourceFiles at: 2.
+	(changesFile isNil or: [ changesFile name = '/dev/null' ])
+		ifTrue: [ self error: 'Save is only available in dev mode. Start with --dev --image.' ].
+	self class headlessSaveAsNewVersion.
+	^ 'Saved as new version: ', Smalltalk imageName.! !
+
+!MCPServer class methodsFor: 'system startup' stamp: 'jmm 1/30/2026 03:45'!
+getenv: varName
+	"Portable environment variable access.
+	 Cuis has Smalltalk getenv: built in.
+	 Squeak 6.0 does not — must use OSProcess.
+	 Returns the value as a String, or nil if not set.
+	 
+	 Note: In startUp:, this is called BEFORE OSProcess session refresh.
+	 That is safe because OSProcess environment access reads /proc/self/environ
+	 (or equivalent) which does not depend on session state."
+	
+	(Smalltalk respondsTo: #getenv:) ifTrue: [
+		^ Smalltalk getenv: varName ].
+	
+	"Squeak with OSProcess"
+	^ [ | env |
+		env := OSProcess thisOSProcess environment.
+		env at: varName ifAbsent: [ nil ] ]
+	on: Error do: [ :e | nil ].! !
+
+!MCPServer class methodsFor: 'system startup' stamp: 'jmm 1/30/2026 03:45'!
 startUp: resuming
-	"Called on image startup - check for --mcp flag"
+	"Called on image startup. Two modes:
+	 1. --mcp flag: Original Claude Code MCP mode (forked, background)
+	 2. SMALLTALK_MCP_DAEMON=1 env var: Daemon mode (inline, blocking)
+	 
+	 Daemon mode runs during processStartUpList: which fires BEFORE
+	 Project current wakeUpTopWindow — critical for headless operation
+	 under xvfb-run where Morphic operations would block."
 	| args |
 	resuming ifFalse: [ ^ self ].
+	
+	"Daemon mode — set by smalltalk-daemon.py via env var"
+	(self getenv: 'SMALLTALK_MCP_DAEMON') = '1' ifTrue: [
+		^ self startDaemon ].
+	
+	"Original MCP mode — set by --mcp command line flag"
 	args := Smalltalk arguments.
 	(args includes: '--mcp') ifTrue: [
 		self startServer ].! !
 
-!MCPServer class methodsFor: 'version' stamp: 'jmm 1/25/2026 18:20'!
+!MCPServer class methodsFor: 'version' stamp: 'jmm 1/30/2026 03:45'!
 version
 	"Return the MCP server version number.
 	 Increment when making changes that external tools should detect.
 	 Version history:
 	   1 - Initial version
-	   2 - Fixed toolDefineMethod: to use compileSilently: for headless operation"
-	^ 2! !
+	   2 - Fixed toolDefineMethod: to use compileSilently: for headless operation
+	   3 - JMM-515: OSProcess session refresh fix for MCP stdin/stdout
+	   4 - JMM-512: Dev mode with save_image and save_as_new_version tools
+	   5 - JMM-515: Daemon mode via startUp: (no --doit needed)
+	   6 - JMM-515: Fix getenv: for Squeak (Cuis-only method)
+	   7 - JMM-509: Class-side method support in browse and method-source"
+	^ 7! !
 
-!MCPServer class methodsFor: 'instance creation' stamp: 'Claude 1/21/2026 12:00'!
+!MCPServer class methodsFor: 'instance creation' stamp: 'jmm 1/30/2026 03:45'!
 startServer
 	"Start the MCP server in a background process.
-	Redirects changes file to /dev/null to allow multiple MCP instances
-	without conflicting writes to the same .changes file."
-
-	"Disable changes file to avoid conflicts with multiple MCP sessions"
-	SourceFiles at: 2 put: (FileStream fileNamed: '/dev/null').
+	In playground mode: Redirects changes file to /dev/null for safety.
+	In dev mode (SMALLTALK_DEV_MODE=1): Keeps changes file for persistence."
+	
+	| devMode |
+	
+	"CRITICAL: Refresh OSProcess handles for new VM session (JMM-515).
+	 After image save/restore, OSProcess session ID becomes stale,
+	 causing stdin/stdout to report as closed. This refresh reattaches
+	 the file handles to the current VM session."
+	OSProcess thisOSProcess refreshFromProcessAccessor.
+	
+	devMode := (self getenv: 'SMALLTALK_DEV_MODE') = '1'.
+	
+	devMode 
+		ifTrue: [
+			"Dev mode - keep changes file for persistence"
+			Transcript show: 'MCP Server starting in DEVELOPMENT mode (changes enabled)'; cr ]
+		ifFalse: [
+			"Playground mode - disable changes file for safety"
+			SourceFiles at: 2 put: (FileStream fileNamed: '/dev/null').
+			Transcript show: 'MCP Server starting in PLAYGROUND mode (changes disabled)'; cr ].
 
 	[
 		"Brief delay to let system stabilize"
 		(Delay forMilliseconds: 100) wait.
 		self new run
 	] forkAt: Processor userBackgroundPriority named: 'MCP Server'.! !
+
+!MCPServer class methodsFor: 'instance creation' stamp: 'jmm 1/30/2026 03:45'!
+startDaemon
+	"Start MCP server for daemon operation.
+	Called from startUp: when SMALLTALK_MCP_DAEMON=1.
+	Runs inline (blocking) at full priority to avoid green thread starvation.
+	
+	Environment variables:
+	  SMALLTALK_MCP_DAEMON=1  - triggers this mode
+	  SMALLTALK_DEV_MODE=1    - keeps .changes file (else /dev/null)
+	  SMALLTALK_CHANGES_PATH  - explicit path for .changes file (dev mode)"
+	
+	| devMode changesPath |
+	
+	"Refresh OSProcess handles for new VM session (JMM-515)"
+	OSProcess thisOSProcess refreshFromProcessAccessor.
+	
+	"Fix working directory to match image location (may differ cross-platform).
+	 FileDirectory default uses the OS working directory, which may not match
+	 the image location after cross-platform transfer."
+	OSProcess thisOSProcess processAccessor chDir: (FileDirectory dirPathFor: Smalltalk imageName).
+	
+	devMode := (self getenv: 'SMALLTALK_DEV_MODE') = '1'.
+	
+	devMode 
+		ifTrue: [
+			changesPath := self getenv: 'SMALLTALK_CHANGES_PATH'.
+			(changesPath notNil and: [ changesPath notEmpty ])
+				ifTrue: [ SourceFiles at: 2 put: (FileStream oldFileOrNoneNamed: changesPath) ].
+			Transcript show: 'MCP Daemon starting in DEVELOPMENT mode'; cr ]
+		ifFalse: [
+			SourceFiles at: 2 put: (FileStream fileNamed: '/dev/null').
+			Transcript show: 'MCP Daemon starting in PLAYGROUND mode'; cr ].
+	
+	"Run inline — blocks this process, which is fine since we're in startUp:
+	 and don't want Morphic/wakeUpTopWindow to run anyway"
+	self new run.! !
+
+!MCPServer class methodsFor: 'instance creation' stamp: 'jmm 1/30/2026 03:45'!
+startServerInline
+	"Start the MCP server inline (no fork).
+	Used by the daemon's --doit to run the server at full priority,
+	avoiding green thread starvation under xvfb-run.
+	Performs the same setup as startServer but runs synchronously."
+	
+	| devMode |
+	
+	devMode := (self getenv: 'SMALLTALK_DEV_MODE') = '1'.
+	
+	devMode 
+		ifTrue: [
+			Transcript show: 'MCP Server starting INLINE in DEVELOPMENT mode (changes enabled)'; cr ]
+		ifFalse: [
+			SourceFiles at: 2 put: (FileStream fileNamed: '/dev/null').
+			Transcript show: 'MCP Server starting INLINE in PLAYGROUND mode (changes disabled)'; cr ].
+
+	self new run.! !
+
+!MCPServer class methodsFor: 'saving' stamp: 'jmm 1/29/2026 21:10'!
+headlessSaveAsNewVersion
+	"Save image/changes as next version number, headlessly.
+	Based on SmalltalkImage>>saveAsNewVersion but using headlessSave
+	instead of snapshot:andQuit: to avoid UI hangs."
+	
+	| baseName dotIndex newName newChanges |
+	
+	baseName := FileDirectory baseNameFor: 
+		(FileDirectory default localNameFor: Smalltalk imageName).
+	dotIndex := baseName lastIndexOf: FileDirectory dot asCharacter
+		ifAbsent: [ nil ].
+	(dotIndex notNil and: [ (baseName copyFrom: dotIndex + 1 to: baseName size) isAllDigits ])
+		ifTrue: [ baseName := baseName copyFrom: 1 to: dotIndex - 1 ].
+	
+	newName := FileDirectory default nextNameFor: baseName 
+		extension: FileDirectory imageSuffix.
+	newChanges := Smalltalk fullNameForChangesNamed: newName.
+	
+	(FileDirectory default fileOrDirectoryExists: newChanges)
+		ifTrue: [ self error: 'Changes file already exists: ', newChanges ].
+	
+	"Close current sources, copy changes, reopen with new name"
+	(SourceFiles at: 2) ifNotNil: [
+		Smalltalk closeSourceFiles.
+		Smalltalk saveChangesInFileNamed: (Smalltalk fullNameForChangesNamed: newName) ].
+	
+	"Rename image to new version and save"
+	Smalltalk changeImageNameTo: 
+		(FileDirectory default fullNameFor: (Smalltalk fullNameForImageNamed: newName)).
+	Smalltalk openSourceFiles.
+	
+	self headlessSave.! !
+
+!MCPServer class methodsFor: 'saving' stamp: 'jmm 1/29/2026 21:00'!
+headlessSave
+	"Save the image without Cursor/Morphic operations.
+	Based on SmalltalkImage>>snapshot:andQuit:withExitCode:embedded: but
+	stripped of UI entanglements that hang under xvfb-run:
+	  - No Cursor write/normal show
+	  - No Project current wakeUpTopWindow
+	  - No processShutDownList (we are not quitting)
+	  - No startUpPostSnapshot (we are not resuming from snapshot)
+	Changes file logging IS preserved for traceability."
+	
+	| changesLog result |
+	
+	"Flush weak references"
+	Object flushDependents.
+	Object flushEvents.
+	
+	"Log to changes file"
+	(SourceFiles at: 2) ifNotNil: [ :changesFile |
+		changesLog := String streamContents: [ :s |
+			s nextPutAll: '----SNAPSHOT----';
+			  print: Date dateAndTimeNow;
+			  space;
+			  nextPutAll: (FileDirectory default localNameFor: Smalltalk imageName);
+			  nextPutAll: ' priorSource: ';
+			  print: Smalltalk lastQuitLogPosition ].
+		Smalltalk assureStartupStampLogged.
+		Smalltalk lastQuitLogPosition: (SourceFiles at: 2) setToEnd position.
+		Smalltalk logChange: changesLog.
+		Transcript cr; show: changesLog ].
+	
+	"Save"
+	result := Smalltalk snapshotPrimitive.
+	
+	result ifNil: [ self error: 'Failed to write image file (disk full?)' ].
+	
+	"After save, result is false (continuing from save point).
+	 If image is later restored, result would be true (resuming)."
+	^ result! !
 
 "After filing in, run:
   Installer squeakMap install: 'OSProcess'.

--- a/OPENAI-SETUP.md
+++ b/OPENAI-SETUP.md
@@ -1,6 +1,6 @@
 # OpenAI Bridge for Squeak MCP Server
 
-This guide explains how to set up the OpenAI bridge that connects ChatGPT to the Squeak MCP server, allowing ChatGPT to execute Smalltalk code via the same 12 tools that Claude Code uses.
+This guide explains how to set up the OpenAI bridge that connects ChatGPT to the Squeak MCP server, allowing ChatGPT to execute Smalltalk code via the same 14 tools that Claude Code uses.
 
 ## Architecture
 
@@ -46,7 +46,7 @@ Quick summary:
 2. Install OSProcess package via Monticello
 3. File in MCP-Server-Squeak.st
 4. Register startup: Smalltalk addToStartUpList: MCPServer
-5. Save image as ClaudeSqueak6.0.image
+5. Save image as ClaudeSqueak.image
 
 ### 4. Configure Environment Variables
 
@@ -58,7 +58,7 @@ Optional (with defaults shown):
 
     export OPENAI_MODEL="gpt-4o"
     export SQUEAK_VM_PATH="/Applications/Squeak6.0-22148-64bit.app/Contents/MacOS/Squeak"
-    export SQUEAK_IMAGE_PATH="/path/to/ClaudeSqueak6.0.image"
+    export SQUEAK_IMAGE_PATH="/path/to/ClaudeSqueak.image"
 
 ## Usage
 
@@ -88,6 +88,10 @@ This starts an interactive chat session where you can ask ChatGPT questions abou
 | smalltalk_subclasses | Get immediate subclasses of a class |
 | smalltalk_list_categories | List all system categories |
 | smalltalk_classes_in_category | List classes in a category |
+| smalltalk_save_image | Save the current image in place (dev mode only) |
+| smalltalk_save_as_new_version | Save image/changes as next version number (dev mode only) |
+
+**Note:** `smalltalk_save_image` and `smalltalk_save_as_new_version` are only available when `SMALLTALK_DEV_MODE=1`. The OpenAI bridge uses `--mcp` mode which runs in playground mode by default.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Developed by John M McIntosh, Corporate Smalltalk Consulting Ltd. 2026
 - **Responsive GUI** - Cuis GUI remains responsive during MCP operations
 - Uses OSProcess with `BufferedAsyncFileReadStream` for non-blocking stdio
 - Claude spawns the Cuis image directly
-- 12 tools available (saveImage intentionally excluded for safety)
+- 14 tools available (includes save tools in dev mode, class-side method support in v7)
 
 ### Option C: Squeak Native MCP (RECOMMENDED for Squeak)
 
@@ -37,7 +37,7 @@ Developed by John M McIntosh, Corporate Smalltalk Consulting Ltd. 2026
 
 - **Responsive GUI** - Squeak GUI remains responsive during MCP operations
 - Uses OSProcess with `BufferedAsyncFileReadStream` for non-blocking stdio
-- 12 tools available (same as Cuis)
+- 14 tools available (v7 — class-side method support, save tools in dev mode)
 - Server-side processing: 0-3ms per request
 
 ### Option A: Python/MQTT Bridge
@@ -62,7 +62,7 @@ Developed by John M McIntosh, Corporate Smalltalk Consulting Ltd. 2026
 └─────────────┘                └─────────────────┘                 └─────────────────┘
 ```
 
-- Enables **ChatGPT** to execute Smalltalk code via the same 12 tools
+- Enables **ChatGPT** to execute Smalltalk code via the same 14 tools
 - Requires Python 3.10+ and OpenAI API key
 - See [OPENAI-SETUP.md](OPENAI-SETUP.md) for detailed instructions
 
@@ -77,6 +77,9 @@ Developed by John M McIntosh, Corporate Smalltalk Consulting Ltd. 2026
 ```
 
 - Enables **Clawdbot** (Telegram/Discord AI agent) to interact with Smalltalk
+- Persistent daemon mode with Unix socket — VM stays running between conversations
+- Playground mode (ephemeral) and dev mode (persistent) with project management
+- LLM-powered explain and audit tools (requires OpenAI API key)
 - Includes debug tools: `--check` (verify setup) and `--debug` (SIGUSR1 stack trace + screenshot)
 - See [CLAWDBOT-SETUP.md](CLAWDBOT-SETUP.md) for detailed instructions
 
@@ -371,8 +374,8 @@ This generates `/tmp/ClaudeSmalltalkDebug_YYYYMMDD_HHMMSS.html` with:
 | Tool | Description |
 |------|-------------|
 | `smalltalk_evaluate` | Execute Smalltalk code and return result |
-| `smalltalk_browse` | Get class metadata (superclass, instance vars, methods) |
-| `smalltalk_method_source` | View source code of a method |
+| `smalltalk_browse` | Get class metadata (superclass, instance vars, instance `methods` and `classMethods`) |
+| `smalltalk_method_source` | View source code of a method (supports `side` param for class-side methods) |
 | `smalltalk_define_class` | Create or modify a class definition |
 | `smalltalk_define_method` | Add or update a method |
 | `smalltalk_delete_method` | Remove a method from a class |
@@ -382,6 +385,10 @@ This generates `/tmp/ClaudeSmalltalkDebug_YYYYMMDD_HHMMSS.html` with:
 | `smalltalk_subclasses` | Get immediate subclasses of a class |
 | `smalltalk_list_categories` | List all system categories |
 | `smalltalk_classes_in_category` | List classes in a category |
+| `smalltalk_save_image` | Save the current image in place (dev mode only) |
+| `smalltalk_save_as_new_version` | Save image/changes as next version number (dev mode only) |
+
+**Note:** `smalltalk_save_image` and `smalltalk_save_as_new_version` are only available when `SMALLTALK_DEV_MODE=1`. In playground mode (default), these return errors.
 
 ## Usage Examples
 
@@ -390,6 +397,7 @@ Once configured, you can ask Claude:
 - "Evaluate `3 factorial` in Smalltalk"
 - "Browse the OrderedCollection class"
 - "Show me the source of String>>asUppercase"
+- "Show me the class method MCPServer class>>version"
 - "What are the subclasses of Collection?"
 - "Create a new class called Counter with an instance variable 'count'"
 

--- a/clawdbot/SKILL.md
+++ b/clawdbot/SKILL.md
@@ -39,8 +39,12 @@ python3 smalltalk.py evaluate "Date today"
 # Browse a class
 python3 smalltalk.py browse OrderedCollection
 
-# View method source
+# View method source (instance side)
 python3 smalltalk.py method-source String asUppercase
+
+# View method source (class side)
+python3 smalltalk.py method-source "MCPServer class" version
+python3 smalltalk.py method-source MCPServer version --class-side
 
 # List classes (with optional prefix filter)
 python3 smalltalk.py list-classes Collection
@@ -74,23 +78,38 @@ python3 smalltalk.py delete-class Counter
 
 ## Operating Modes
 
-### Exec Mode (Default)
-Each command spawns a fresh VM. State does not persist between calls.
-Best for read-only queries (browse, evaluate, hierarchy).
-
-### Daemon Mode (Persistent)
-A single VM stays running. State persists across calls.
-Best for development sessions with define-class/define-method.
+### Playground (Default)
+Stock image, ephemeral. Changes are discarded when daemon stops.
+User says: "load Smalltalk skill" or "invoke Smalltalk" — no special flags.
 
 ```bash
-# Start daemon (use nohup to prevent SIGKILL)
+# Start playground daemon
 nohup python3 smalltalk-daemon.py start > /tmp/daemon.log 2>&1 &
+```
 
+### Dev Mode
+User supplies their own image/changes pair. Changes persist across sessions.
+User says: "load Smalltalk skill in dev mode with ~/MyProject.image"
+
+```bash
+# Start dev daemon with custom image
+nohup python3 smalltalk-daemon.py start --dev --image ~/MyProject.image > /tmp/daemon.log 2>&1 &
+```
+
+Dev mode sets `SMALLTALK_DEV_MODE=1` so the MCP server keeps the .changes file
+(instead of redirecting to /dev/null). The supplied image must have a matching
+.changes file alongside it.
+
+### Common Commands
+```bash
 # Check status
 python3 smalltalk.py --daemon-status
 
 # Stop daemon
 python3 smalltalk-daemon.py stop
+
+# Restart in dev mode
+python3 smalltalk-daemon.py restart --dev --image ~/MyProject.image
 ```
 
 ## Commands
@@ -101,8 +120,8 @@ python3 smalltalk-daemon.py stop
 | `--daemon-status` | Check if daemon is running |
 | `--debug` | Debug hung system (sends SIGUSR1, captures stack trace) |
 | `evaluate <code>` | Execute Smalltalk code, return result |
-| `browse <class>` | Get class metadata (superclass, ivars, methods) |
-| `method-source <class> <selector>` | View method source code |
+| `browse <class>` | Get class metadata (superclass, ivars, instance `methods` and `classMethods`) |
+| `method-source <class> <selector> [--class-side]` | View method source code (supports `"Class class"` syntax or `--class-side` flag) |
 | `define-class <definition>` | Create or modify a class |
 | `define-method <class> <source>` | Add or update a method |
 | `delete-method <class> <selector>` | Remove a method |
@@ -112,6 +131,10 @@ python3 smalltalk-daemon.py stop
 | `subclasses <class>` | Get immediate subclasses |
 | `list-categories` | List all system categories |
 | `classes-in-category <cat>` | List classes in a category |
+| `explain <code>` | Explain Smalltalk code (requires `OPENAI_API_KEY`) |
+| `explain-method <class> <sel> [--class-side]` | Fetch method from image and explain it |
+| `audit-comment <class> <sel> [--class-side]` | Audit method comment vs implementation |
+| `audit-class <class>` | Audit all methods in a class (instance + class side) |
 
 ## Environment Variables
 
@@ -119,11 +142,14 @@ python3 smalltalk-daemon.py stop
 |----------|-------------|
 | `SQUEAK_VM_PATH` | Path to Squeak/Cuis VM executable |
 | `SQUEAK_IMAGE_PATH` | Path to Smalltalk image with MCP server |
+| `OPENAI_API_KEY` | Required for explain/audit LLM tools |
+| `OPENAI_MODEL` | Model for LLM tools (default: `gpt-4o-mini`) |
 
 ## Notes
 
 - Requires xvfb for headless operation on Linux servers
 - Uses Squeak 6.0 MCP server (GUI stays responsive if display available)
 - `saveImage` intentionally excluded for safety
-- MCPServer version 2+ required for headless `define-method` (check with `--check`)
-- Daemon mode recommended for define-class/define-method workflows
+- MCPServer version 7+ required (v7 adds class-side method support)
+- Playground mode: ephemeral, .changes → /dev/null
+- Dev mode: persistent, .changes kept, requires `--dev --image PATH`

--- a/clawdbot/smalltalk-dev-daemon.py
+++ b/clawdbot/smalltalk-dev-daemon.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Smalltalk Development Daemon
+Runs a Squeak image with changes file enabled for persistent development.
+
+Unlike the MCP daemon (which disables changes for safety), this daemon:
+- Uses the actual .changes file
+- Allows saving the image
+- Supports multiple concurrent dev images
+"""
+
+import os
+import sys
+import socket
+import subprocess
+import signal
+import json
+import time
+from pathlib import Path
+
+SOCKET_DIR = Path('/tmp/smalltalk-dev')
+DEFAULT_PORT_BASE = 9100
+
+def get_socket_path(project_name):
+    """Get socket path for a project."""
+    SOCKET_DIR.mkdir(exist_ok=True)
+    return SOCKET_DIR / f'{project_name}.sock'
+
+def get_pid_file(project_name):
+    """Get PID file path for a project."""
+    return SOCKET_DIR / f'{project_name}.pid'
+
+def is_running(project_name):
+    """Check if daemon is running for project."""
+    pid_file = get_pid_file(project_name)
+    if not pid_file.exists():
+        return False
+    try:
+        pid = int(pid_file.read_text().strip())
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, ValueError):
+        pid_file.unlink(missing_ok=True)
+        return False
+
+def start_daemon(project_name, image_path, changes_path, vm_path=None):
+    """Start development daemon for a project."""
+    if is_running(project_name):
+        print(f"✅ Daemon already running for {project_name}")
+        return True
+    
+    image_path = Path(image_path)
+    changes_path = Path(changes_path)
+    
+    if not image_path.exists():
+        print(f"❌ Image not found: {image_path}")
+        return False
+    if not changes_path.exists():
+        print(f"❌ Changes not found: {changes_path}")
+        return False
+    
+    # Find VM
+    if vm_path is None:
+        vm_path = os.environ.get('SQUEAK_VM_PATH', 
+            '/home/johnmci/Squeak6.0-22148-64bit-202312181441-Linux-x64/bin/squeak')
+    
+    if not Path(vm_path).exists():
+        print(f"❌ VM not found: {vm_path}")
+        return False
+    
+    socket_path = get_socket_path(project_name)
+    pid_file = get_pid_file(project_name)
+    
+    # Start with xvfb for headless operation
+    cmd = [
+        'xvfb-run', '-a',
+        vm_path,
+        str(image_path),
+        '--mcp'  # Still use MCP protocol for communication
+    ]
+    
+    print(f"🚀 Starting development daemon for {project_name}...")
+    print(f"   Image: {image_path}")
+    print(f"   Changes: {changes_path}")
+    
+    # Start process
+    # Note: For dev mode, we DON'T redirect changes to /dev/null
+    # The Squeak startup code needs modification to not disable changes in dev mode
+    # For now, we'll pass an env var to signal dev mode
+    env = os.environ.copy()
+    env['SMALLTALK_DEV_MODE'] = '1'
+    env['SMALLTALK_PROJECT'] = project_name
+    
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+        start_new_session=True
+    )
+    
+    pid_file.write_text(str(proc.pid))
+    
+    # Wait for startup
+    time.sleep(5)
+    
+    if proc.poll() is None:
+        print(f"✅ Development daemon started (PID {proc.pid})")
+        return True
+    else:
+        print(f"❌ Daemon failed to start")
+        pid_file.unlink(missing_ok=True)
+        return False
+
+def stop_daemon(project_name):
+    """Stop development daemon for a project."""
+    pid_file = get_pid_file(project_name)
+    if not pid_file.exists():
+        print(f"ℹ️  No daemon running for {project_name}")
+        return
+    
+    try:
+        pid = int(pid_file.read_text().strip())
+        print(f"🛑 Stopping daemon for {project_name} (PID {pid})...")
+        os.kill(pid, signal.SIGTERM)
+        time.sleep(2)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        print(f"✅ Daemon stopped")
+    except Exception as e:
+        print(f"⚠️  Error stopping daemon: {e}")
+    finally:
+        pid_file.unlink(missing_ok=True)
+        socket_path = get_socket_path(project_name)
+        socket_path.unlink(missing_ok=True)
+
+def status_daemon(project_name=None):
+    """Show daemon status."""
+    if project_name:
+        if is_running(project_name):
+            pid = get_pid_file(project_name).read_text().strip()
+            print(f"✅ {project_name}: Running (PID {pid})")
+        else:
+            print(f"❌ {project_name}: Not running")
+    else:
+        # List all running daemons
+        if not SOCKET_DIR.exists():
+            print("No development daemons running.")
+            return
+        
+        pids = list(SOCKET_DIR.glob('*.pid'))
+        if not pids:
+            print("No development daemons running.")
+            return
+        
+        print("🔧 Development Daemons:")
+        for pid_file in pids:
+            name = pid_file.stem
+            if is_running(name):
+                pid = pid_file.read_text().strip()
+                print(f"   ✅ {name} (PID {pid})")
+            else:
+                print(f"   ❌ {name} (stale)")
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Smalltalk Development Daemon')
+    parser.add_argument('command', choices=['start', 'stop', 'status', 'restart'])
+    parser.add_argument('--project', '-p', help='Project name')
+    parser.add_argument('--image', help='Image path')
+    parser.add_argument('--changes', help='Changes file path')
+    parser.add_argument('--vm', help='VM path')
+    
+    args = parser.parse_args()
+    
+    if args.command == 'start':
+        if not args.project or not args.image:
+            print("❌ --project and --image required for start")
+            sys.exit(1)
+        changes = args.changes or str(Path(args.image).with_suffix('.changes'))
+        start_daemon(args.project, args.image, changes, args.vm)
+    
+    elif args.command == 'stop':
+        if not args.project:
+            print("❌ --project required for stop")
+            sys.exit(1)
+        stop_daemon(args.project)
+    
+    elif args.command == 'status':
+        status_daemon(args.project)
+    
+    elif args.command == 'restart':
+        if not args.project or not args.image:
+            print("❌ --project and --image required for restart")
+            sys.exit(1)
+        stop_daemon(args.project)
+        time.sleep(2)
+        changes = args.changes or str(Path(args.image).with_suffix('.changes'))
+        start_daemon(args.project, args.image, changes, args.vm)

--- a/clawdbot/smalltalk_projects.py
+++ b/clawdbot/smalltalk_projects.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+Smalltalk Project Manager for Clawdbot
+JMM-512: Interactive mode selection (Playground vs Development)
+
+Manages:
+- Mode selection (playground/new project/load existing)
+- Recent projects tracking
+- Snapshots for safety
+"""
+
+import os
+import sys
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+# Configuration
+CONFIG_DIR = Path.home() / '.clawdbot' / 'smalltalk'
+RECENT_FILE = CONFIG_DIR / 'recent-projects.json'
+PROJECTS_DIR = Path.home() / 'smalltalk-projects'
+
+def ensure_dirs():
+    """Create config and projects directories if needed."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+
+def load_recent():
+    """Load recent projects list."""
+    if RECENT_FILE.exists():
+        try:
+            return json.loads(RECENT_FILE.read_text())
+        except:
+            return []
+    return []
+
+def save_recent(recent):
+    """Save recent projects list."""
+    ensure_dirs()
+    RECENT_FILE.write_text(json.dumps(recent, indent=2))
+
+def add_to_recent(project_path, project_name):
+    """Add a project to recent list."""
+    recent = load_recent()
+    entry = {
+        'name': project_name,
+        'path': str(project_path),
+        'last_used': datetime.now().isoformat()
+    }
+    # Remove if already exists
+    recent = [r for r in recent if r['path'] != str(project_path)]
+    # Add to front
+    recent.insert(0, entry)
+    # Keep only last 10
+    recent = recent[:10]
+    save_recent(recent)
+
+def list_recent():
+    """List recent projects."""
+    recent = load_recent()
+    if not recent:
+        print("No recent projects.")
+        return []
+    print("\n📂 Recent Projects:")
+    for i, proj in enumerate(recent, 1):
+        last = proj.get('last_used', 'unknown')
+        if last != 'unknown':
+            try:
+                dt = datetime.fromisoformat(last)
+                last = dt.strftime('%Y-%m-%d %H:%M')
+            except:
+                pass
+        exists = "✅" if Path(proj['path']).exists() else "❌"
+        print(f"   {i}. {exists} {proj['name']} ({last})")
+        print(f"      {proj['path']}")
+    return recent
+
+def create_project(name, base_image, base_changes):
+    """Create a new project by copying image and changes."""
+    ensure_dirs()
+    project_dir = PROJECTS_DIR / name
+    
+    if project_dir.exists():
+        print(f"❌ Project '{name}' already exists at {project_dir}")
+        return None
+    
+    # Verify base files exist
+    if not Path(base_image).exists():
+        print(f"❌ Base image not found: {base_image}")
+        return None
+    if not Path(base_changes).exists():
+        print(f"❌ Base changes file not found: {base_changes}")
+        return None
+    
+    # Create project structure
+    project_dir.mkdir(parents=True)
+    snapshots_dir = project_dir / 'snapshots'
+    snapshots_dir.mkdir()
+    
+    # Copy files
+    image_dest = project_dir / f'{name}.image'
+    changes_dest = project_dir / f'{name}.changes'
+    
+    print(f"📁 Creating project: {project_dir}")
+    print(f"   Copying image...")
+    shutil.copy2(base_image, image_dest)
+    print(f"   Copying changes...")
+    shutil.copy2(base_changes, changes_dest)
+    
+    # Create project metadata
+    meta = {
+        'name': name,
+        'created': datetime.now().isoformat(),
+        'base_image': str(base_image),
+        'image': str(image_dest),
+        'changes': str(changes_dest)
+    }
+    (project_dir / 'project.json').write_text(json.dumps(meta, indent=2))
+    
+    add_to_recent(project_dir, name)
+    
+    print(f"✅ Project created: {name}")
+    print(f"   Image: {image_dest}")
+    print(f"   Changes: {changes_dest}")
+    
+    return {
+        'dir': project_dir,
+        'image': image_dest,
+        'changes': changes_dest,
+        'name': name
+    }
+
+def load_project(path):
+    """Load an existing project."""
+    project_dir = Path(path)
+    meta_file = project_dir / 'project.json'
+    
+    if meta_file.exists():
+        meta = json.loads(meta_file.read_text())
+        image = Path(meta['image'])
+        changes = Path(meta['changes'])
+    else:
+        # Try to find image/changes in directory
+        images = list(project_dir.glob('*.image'))
+        if not images:
+            print(f"❌ No .image file found in {project_dir}")
+            return None
+        image = images[0]
+        changes = image.with_suffix('.changes')
+        if not changes.exists():
+            print(f"❌ Changes file not found: {changes}")
+            return None
+        meta = {'name': image.stem}
+    
+    if not image.exists():
+        print(f"❌ Image not found: {image}")
+        return None
+    
+    add_to_recent(project_dir, meta.get('name', project_dir.name))
+    
+    print(f"✅ Loaded project: {meta.get('name', project_dir.name)}")
+    print(f"   Image: {image}")
+    print(f"   Changes: {changes}")
+    
+    return {
+        'dir': project_dir,
+        'image': image,
+        'changes': changes,
+        'name': meta.get('name', project_dir.name)
+    }
+
+def create_snapshot(project_dir, name=None):
+    """Create a snapshot of current project state."""
+    project_dir = Path(project_dir)
+    snapshots_dir = project_dir / 'snapshots'
+    snapshots_dir.mkdir(exist_ok=True)
+    
+    timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    snap_name = name or f'snapshot-{timestamp}'
+    snap_dir = snapshots_dir / snap_name
+    snap_dir.mkdir()
+    
+    # Find and copy image/changes
+    for img in project_dir.glob('*.image'):
+        if 'snapshot' not in str(img):
+            shutil.copy2(img, snap_dir / img.name)
+            changes = img.with_suffix('.changes')
+            if changes.exists():
+                shutil.copy2(changes, snap_dir / changes.name)
+            break
+    
+    print(f"✅ Snapshot created: {snap_name}")
+    return snap_dir
+
+def list_snapshots(project_dir):
+    """List available snapshots."""
+    project_dir = Path(project_dir)
+    snapshots_dir = project_dir / 'snapshots'
+    
+    if not snapshots_dir.exists():
+        print("No snapshots.")
+        return []
+    
+    snaps = sorted(snapshots_dir.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True)
+    if not snaps:
+        print("No snapshots.")
+        return []
+    
+    print("\n📸 Snapshots:")
+    for i, snap in enumerate(snaps, 1):
+        mtime = datetime.fromtimestamp(snap.stat().st_mtime).strftime('%Y-%m-%d %H:%M')
+        print(f"   {i}. {snap.name} ({mtime})")
+    return snaps
+
+def restore_snapshot(project_dir, snapshot_name):
+    """Restore a snapshot."""
+    project_dir = Path(project_dir)
+    snap_dir = project_dir / 'snapshots' / snapshot_name
+    
+    if not snap_dir.exists():
+        print(f"❌ Snapshot not found: {snapshot_name}")
+        return False
+    
+    # Create backup of current state first
+    create_snapshot(project_dir, f'pre-restore-{datetime.now().strftime("%Y%m%d-%H%M%S")}')
+    
+    # Restore files
+    for f in snap_dir.glob('*'):
+        dest = project_dir / f.name
+        print(f"   Restoring {f.name}...")
+        shutil.copy2(f, dest)
+    
+    print(f"✅ Restored snapshot: {snapshot_name}")
+    return True
+
+def interactive_mode_select(default_image, default_changes):
+    """Interactive mode selection menu."""
+    print("\n" + "="*60)
+    print("🎯 Smalltalk Mode Selection")
+    print("="*60)
+    print()
+    print("  1. Playground     - Ephemeral sandbox (no persistence)")
+    print("  2. New Project    - Create saveable working copy")
+    print("  3. Load Project   - Open existing project")
+    
+    recent = load_recent()
+    recent_valid = [r for r in recent if Path(r['path']).exists()]
+    
+    if recent_valid:
+        print()
+        print("  Recent:")
+        for i, proj in enumerate(recent_valid[:3], 4):
+            print(f"  {i}. {proj['name']}")
+    
+    print()
+    choice = input("Select [1]: ").strip() or '1'
+    
+    if choice == '1':
+        return {'mode': 'playground'}
+    
+    elif choice == '2':
+        print()
+        name = input("Project name: ").strip()
+        if not name:
+            print("❌ Name required")
+            return None
+        proj = create_project(name, default_image, default_changes)
+        if proj:
+            return {'mode': 'development', 'project': proj}
+        return None
+    
+    elif choice == '3':
+        print()
+        path = input("Project path or image file: ").strip()
+        if not path:
+            print("❌ Path required")
+            return None
+        path = Path(path).expanduser()
+        if path.suffix == '.image':
+            path = path.parent
+        proj = load_project(path)
+        if proj:
+            return {'mode': 'development', 'project': proj}
+        return None
+    
+    elif choice.isdigit() and int(choice) >= 4:
+        idx = int(choice) - 4
+        if idx < len(recent_valid):
+            proj = load_project(recent_valid[idx]['path'])
+            if proj:
+                return {'mode': 'development', 'project': proj}
+        print("❌ Invalid selection")
+        return None
+    
+    else:
+        print("❌ Invalid selection")
+        return None
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Smalltalk Project Manager')
+    parser.add_argument('command', choices=['select', 'recent', 'create', 'load', 'snapshot', 'snapshots', 'restore'])
+    parser.add_argument('--name', help='Project or snapshot name')
+    parser.add_argument('--path', help='Project path')
+    parser.add_argument('--image', default='/home/johnmci/ClaudeSqueak.image', help='Base image')
+    parser.add_argument('--changes', default='/home/johnmci/ClaudeSqueak.changes', help='Base changes')
+    
+    args = parser.parse_args()
+    
+    if args.command == 'select':
+        result = interactive_mode_select(args.image, args.changes)
+        if result:
+            print(json.dumps(result))
+    elif args.command == 'recent':
+        list_recent()
+    elif args.command == 'create':
+        if not args.name:
+            print("❌ --name required")
+            sys.exit(1)
+        create_project(args.name, args.image, args.changes)
+    elif args.command == 'load':
+        if not args.path:
+            print("❌ --path required")
+            sys.exit(1)
+        load_project(args.path)
+    elif args.command == 'snapshot':
+        if not args.path:
+            print("❌ --path required")
+            sys.exit(1)
+        create_snapshot(args.path, args.name)
+    elif args.command == 'snapshots':
+        if not args.path:
+            print("❌ --path required")
+            sys.exit(1)
+        list_snapshots(args.path)
+    elif args.command == 'restore':
+        if not args.path or not args.name:
+            print("❌ --path and --name required")
+            sys.exit(1)
+        restore_snapshot(args.path, args.name)

--- a/clawdbot/st
+++ b/clawdbot/st
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Smalltalk CLI - Unified interface for playground and development modes
+JMM-512 Implementation
+
+Usage:
+    st                      # Interactive mode selection
+    st playground           # Start playground mode
+    st project new <name>   # Create new project
+    st project load <path>  # Load existing project
+    st project list         # List recent projects
+    st snapshot <name>      # Create snapshot (dev mode)
+    st restore <name>       # Restore snapshot (dev mode)
+    st <command> [args]     # Pass through to smalltalk.py
+"""
+
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+PROJECTS_PY = SCRIPT_DIR / 'smalltalk-projects.py'
+DAEMON_PY = SCRIPT_DIR / 'smalltalk-daemon.py'
+DEV_DAEMON_PY = SCRIPT_DIR / 'smalltalk-dev-daemon.py'
+SMALLTALK_PY = SCRIPT_DIR / 'smalltalk.py'
+STATE_FILE = Path.home() / '.clawdbot' / 'smalltalk' / 'current-mode.json'
+
+DEFAULT_IMAGE = '/home/johnmci/ClaudeSqueak.image'
+DEFAULT_CHANGES = '/home/johnmci/ClaudeSqueak.changes'
+
+def load_state():
+    """Load current mode state."""
+    if STATE_FILE.exists():
+        try:
+            return json.loads(STATE_FILE.read_text())
+        except:
+            pass
+    return {'mode': 'playground'}
+
+def save_state(state):
+    """Save current mode state."""
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+def run_projects(*args):
+    """Run projects manager."""
+    subprocess.run([sys.executable, str(PROJECTS_PY)] + list(args))
+
+def interactive_select():
+    """Interactive mode selection."""
+    from smalltalk_projects import interactive_mode_select, load_recent
+    
+    print("\n" + "="*60)
+    print("🎯 Smalltalk Mode Selection")
+    print("="*60)
+    print()
+    print("  1. Playground     - Ephemeral sandbox (no persistence)")
+    print("  2. New Project    - Create saveable working copy")
+    print("  3. Load Project   - Open existing project")
+    
+    recent = load_recent()
+    recent_valid = [r for r in recent if Path(r['path']).exists()][:3]
+    
+    if recent_valid:
+        print()
+        print("  Recent:")
+        for i, proj in enumerate(recent_valid, 4):
+            print(f"  {i}. {proj['name']}")
+    
+    print()
+    choice = input("Select [1]: ").strip() or '1'
+    
+    if choice == '1':
+        # Playground mode
+        print("\n🎮 Starting Playground mode...")
+        subprocess.run([sys.executable, str(DAEMON_PY), 'start'])
+        save_state({'mode': 'playground'})
+        print("\n✅ Playground ready! Use 'st evaluate \"3+4\"' to test.")
+        
+    elif choice == '2':
+        # New project
+        print()
+        name = input("Project name: ").strip()
+        if not name:
+            print("❌ Name required")
+            return
+        
+        from smalltalk_projects import create_project
+        proj = create_project(name, DEFAULT_IMAGE, DEFAULT_CHANGES)
+        if proj:
+            save_state({
+                'mode': 'development',
+                'project': name,
+                'image': str(proj['image']),
+                'changes': str(proj['changes']),
+                'dir': str(proj['dir'])
+            })
+            print(f"\n🚀 Starting development daemon for {name}...")
+            subprocess.run([
+                sys.executable, str(DEV_DAEMON_PY), 'start',
+                '--project', name,
+                '--image', str(proj['image']),
+                '--changes', str(proj['changes'])
+            ])
+            print(f"\n✅ Project '{name}' ready!")
+            
+    elif choice == '3':
+        # Load project
+        print()
+        path = input("Project path: ").strip()
+        if not path:
+            print("❌ Path required")
+            return
+        
+        from smalltalk_projects import load_project
+        proj = load_project(Path(path).expanduser())
+        if proj:
+            save_state({
+                'mode': 'development',
+                'project': proj['name'],
+                'image': str(proj['image']),
+                'changes': str(proj['changes']),
+                'dir': str(proj['dir'])
+            })
+            print(f"\n🚀 Starting development daemon...")
+            subprocess.run([
+                sys.executable, str(DEV_DAEMON_PY), 'start',
+                '--project', proj['name'],
+                '--image', str(proj['image']),
+                '--changes', str(proj['changes'])
+            ])
+            print(f"\n✅ Project '{proj['name']}' ready!")
+            
+    elif choice.isdigit() and int(choice) >= 4:
+        # Recent project
+        idx = int(choice) - 4
+        if idx < len(recent_valid):
+            from smalltalk_projects import load_project
+            proj = load_project(recent_valid[idx]['path'])
+            if proj:
+                save_state({
+                    'mode': 'development',
+                    'project': proj['name'],
+                    'image': str(proj['image']),
+                    'changes': str(proj['changes']),
+                    'dir': str(proj['dir'])
+                })
+                print(f"\n🚀 Starting development daemon...")
+                subprocess.run([
+                    sys.executable, str(DEV_DAEMON_PY), 'start',
+                    '--project', proj['name'],
+                    '--image', str(proj['image']),
+                    '--changes', str(proj['changes'])
+                ])
+                print(f"\n✅ Project '{proj['name']}' ready!")
+        else:
+            print("❌ Invalid selection")
+
+def main():
+    # Add script dir to path for imports
+    sys.path.insert(0, str(SCRIPT_DIR))
+    
+    if len(sys.argv) < 2:
+        # No args - interactive mode
+        interactive_select()
+        return
+    
+    cmd = sys.argv[1]
+    args = sys.argv[2:]
+    
+    if cmd == 'mode':
+        # Show current mode
+        state = load_state()
+        print(f"Current mode: {state.get('mode', 'unknown')}")
+        if state.get('project'):
+            print(f"Project: {state['project']}")
+            print(f"Image: {state.get('image')}")
+        
+    elif cmd == 'playground':
+        # Switch to playground
+        subprocess.run([sys.executable, str(DAEMON_PY), 'start'])
+        save_state({'mode': 'playground'})
+        print("✅ Playground mode active")
+        
+    elif cmd == 'project':
+        if not args:
+            print("Usage: st project [new|load|list|snapshot|restore]")
+            return
+        subcmd = args[0]
+        subargs = args[1:]
+        
+        if subcmd == 'new':
+            if not subargs:
+                print("Usage: st project new <name>")
+                return
+            name = subargs[0]
+            from smalltalk_projects import create_project
+            proj = create_project(name, DEFAULT_IMAGE, DEFAULT_CHANGES)
+            if proj:
+                save_state({
+                    'mode': 'development',
+                    'project': name,
+                    'image': str(proj['image']),
+                    'changes': str(proj['changes']),
+                    'dir': str(proj['dir'])
+                })
+                
+        elif subcmd == 'load':
+            if not subargs:
+                print("Usage: st project load <path>")
+                return
+            from smalltalk_projects import load_project
+            proj = load_project(Path(subargs[0]).expanduser())
+            if proj:
+                save_state({
+                    'mode': 'development',
+                    'project': proj['name'],
+                    'image': str(proj['image']),
+                    'changes': str(proj['changes']),
+                    'dir': str(proj['dir'])
+                })
+                
+        elif subcmd == 'list':
+            from smalltalk_projects import list_recent
+            list_recent()
+            
+        elif subcmd == 'snapshot':
+            state = load_state()
+            if state.get('mode') != 'development':
+                print("❌ Snapshots only available in development mode")
+                return
+            name = subargs[0] if subargs else None
+            from smalltalk_projects import create_snapshot
+            create_snapshot(state['dir'], name)
+            
+        elif subcmd == 'restore':
+            state = load_state()
+            if state.get('mode') != 'development':
+                print("❌ Restore only available in development mode")
+                return
+            if not subargs:
+                from smalltalk_projects import list_snapshots
+                list_snapshots(state['dir'])
+            else:
+                from smalltalk_projects import restore_snapshot
+                restore_snapshot(state['dir'], subargs[0])
+    
+    elif cmd == 'snapshot':
+        # Shortcut for project snapshot
+        state = load_state()
+        if state.get('mode') != 'development':
+            print("❌ Snapshots only available in development mode")
+            return
+        name = args[0] if args else None
+        from smalltalk_projects import create_snapshot
+        create_snapshot(state['dir'], name)
+        
+    elif cmd == 'restore':
+        # Shortcut for project restore
+        state = load_state()
+        if state.get('mode') != 'development':
+            print("❌ Restore only available in development mode")
+            return
+        if not args:
+            from smalltalk_projects import list_snapshots
+            list_snapshots(state['dir'])
+        else:
+            from smalltalk_projects import restore_snapshot
+            restore_snapshot(state['dir'], args[0])
+    
+    else:
+        # Pass through to smalltalk.py
+        subprocess.run([sys.executable, str(SMALLTALK_PY), cmd] + args)
+
+if __name__ == '__main__':
+    main()

--- a/examples/SKILL.md
+++ b/examples/SKILL.md
@@ -1,44 +1,155 @@
 ---
 name: smalltalk
 description: Interact with live Smalltalk image (Cuis or Squeak). Use for evaluating Smalltalk code, browsing classes, viewing method source, defining classes/methods, querying hierarchy and categories.
-allowed-tools: squeakDirect/.*|cuisDirect/.*|claudeCuis/.*
-user-invocable: true
+metadata: {"clawdbot":{"emoji":"💎","requires":{"bins":["python3","xvfb-run"]}}}
 ---
 
-# Smalltalk Development Mode
+# Smalltalk Skill
 
-You have access to a **live Smalltalk image** via the MCP server (any of the four options).
+Execute Smalltalk code and browse live Squeak/Cuis images via MCP.
 
-**Note:** The MCP server name in tool calls depends on your configuration:
-- `squeakDirect` - Native Squeak MCP (Option C, recommended)
-- `cuisDirect` - Native Cuis MCP (Option B)
-- `claudeCuis` - Python/MQTT bridge (Option A)
+## Prerequisites
 
-## Available Tools
+**Get the ClaudeSmalltalk repo first:**
 
-| Tool | Description |
-|------|-------------|
-| `smalltalk_evaluate` | Execute Smalltalk code and return result |
-| `smalltalk_browse` | Get class metadata (superclass, instance vars, methods) |
-| `smalltalk_method_source` | View source code of a method |
-| `smalltalk_define_class` | Create or modify a class definition |
-| `smalltalk_define_method` | Add or update a method |
-| `smalltalk_delete_method` | Remove a method from a class |
-| `smalltalk_delete_class` | Remove a class from the system |
-| `smalltalk_list_classes` | List classes matching a prefix |
-| `smalltalk_hierarchy` | Get superclass chain for a class |
-| `smalltalk_subclasses` | Get immediate subclasses of a class |
-| `smalltalk_list_categories` | List all system categories |
-| `smalltalk_classes_in_category` | List classes in a category |
+```bash
+git clone https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk.git
+```
 
-## Examples
+This repo contains:
+- MCP server code for Squeak (`MCP-Server-Squeak.st`)
+- Setup documentation (`SQUEAK-SETUP.md`, `CLAWDBOT-SETUP.md`)
+- This Clawdbot skill (`clawdbot/`)
 
-- "Evaluate `3 + 4`" - runs code and returns result
-- "Browse the String class" - shows class metadata
-- "Show me Object>>yourself" - displays method source
-- "What subclasses does Collection have?" - queries hierarchy
+## Setup
+
+1. **Set up Squeak with MCP server** — see [SQUEAK-SETUP.md](https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk/blob/main/SQUEAK-SETUP.md)
+2. **Configure Clawdbot** — see [CLAWDBOT-SETUP.md](https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk/blob/main/CLAWDBOT-SETUP.md)
+
+## Usage
+
+```bash
+# Check setup
+python3 smalltalk.py --check
+
+# Evaluate code
+python3 smalltalk.py evaluate "3 factorial"
+python3 smalltalk.py evaluate "Date today"
+
+# Browse a class
+python3 smalltalk.py browse OrderedCollection
+
+# View method source (instance side)
+python3 smalltalk.py method-source String asUppercase
+
+# View method source (class side)
+python3 smalltalk.py method-source "MCPServer class" version
+python3 smalltalk.py method-source MCPServer version --class-side
+
+# List classes (with optional prefix filter)
+python3 smalltalk.py list-classes Collection
+
+# Get class hierarchy
+python3 smalltalk.py hierarchy OrderedCollection
+
+# Get subclasses  
+python3 smalltalk.py subclasses Collection
+
+# List all categories
+python3 smalltalk.py list-categories
+
+# List classes in a category
+python3 smalltalk.py classes-in-category "Collections-Sequenceable"
+
+# Define a new class
+python3 smalltalk.py define-class "Object subclass: #Counter instanceVariableNames: 'count' classVariableNames: '' poolDictionaries: '' category: 'MyApp'"
+
+# Define a method
+python3 smalltalk.py define-method Counter "increment
+    count := (count ifNil: [0]) + 1.
+    ^ count"
+
+# Delete a method
+python3 smalltalk.py delete-method Counter increment
+
+# Delete a class
+python3 smalltalk.py delete-class Counter
+```
+
+## Operating Modes
+
+### Playground (Default)
+Stock image, ephemeral. Changes are discarded when daemon stops.
+User says: "load Smalltalk skill" or "invoke Smalltalk" — no special flags.
+
+```bash
+# Start playground daemon
+nohup python3 smalltalk-daemon.py start > /tmp/daemon.log 2>&1 &
+```
+
+### Dev Mode
+User supplies their own image/changes pair. Changes persist across sessions.
+User says: "load Smalltalk skill in dev mode with ~/MyProject.image"
+
+```bash
+# Start dev daemon with custom image
+nohup python3 smalltalk-daemon.py start --dev --image ~/MyProject.image > /tmp/daemon.log 2>&1 &
+```
+
+Dev mode sets `SMALLTALK_DEV_MODE=1` so the MCP server keeps the .changes file
+(instead of redirecting to /dev/null). The supplied image must have a matching
+.changes file alongside it.
+
+### Common Commands
+```bash
+# Check status
+python3 smalltalk.py --daemon-status
+
+# Stop daemon
+python3 smalltalk-daemon.py stop
+
+# Restart in dev mode
+python3 smalltalk-daemon.py restart --dev --image ~/MyProject.image
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `--check` | Verify VM/image paths and dependencies |
+| `--daemon-status` | Check if daemon is running |
+| `--debug` | Debug hung system (sends SIGUSR1, captures stack trace) |
+| `evaluate <code>` | Execute Smalltalk code, return result |
+| `browse <class>` | Get class metadata (superclass, ivars, instance `methods` and `classMethods`) |
+| `method-source <class> <selector> [--class-side]` | View method source code (supports `"Class class"` syntax or `--class-side` flag) |
+| `define-class <definition>` | Create or modify a class |
+| `define-method <class> <source>` | Add or update a method |
+| `delete-method <class> <selector>` | Remove a method |
+| `delete-class <class>` | Remove a class |
+| `list-classes [prefix]` | List classes, optionally filtered |
+| `hierarchy <class>` | Get superclass chain |
+| `subclasses <class>` | Get immediate subclasses |
+| `list-categories` | List all system categories |
+| `classes-in-category <cat>` | List classes in a category |
+| `explain <code>` | Explain Smalltalk code (requires `OPENAI_API_KEY`) |
+| `explain-method <class> <sel> [--class-side]` | Fetch method from image and explain it |
+| `audit-comment <class> <sel> [--class-side]` | Audit method comment vs implementation |
+| `audit-class <class>` | Audit all methods in a class (instance + class side) |
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `SQUEAK_VM_PATH` | Path to Squeak/Cuis VM executable |
+| `SQUEAK_IMAGE_PATH` | Path to Smalltalk image with MCP server |
+| `OPENAI_API_KEY` | Required for explain/audit LLM tools |
+| `OPENAI_MODEL` | Model for LLM tools (default: `gpt-4o-mini`) |
 
 ## Notes
 
-- Results are returned as strings (use `printString` for objects)
-- Errors include stack traces for debugging
+- Requires xvfb for headless operation on Linux servers
+- Uses Squeak 6.0 MCP server (GUI stays responsive if display available)
+- `saveImage` intentionally excluded for safety
+- MCPServer version 7+ required (v7 adds class-side method support)
+- Playground mode: ephemeral, .changes → /dev/null
+- Dev mode: persistent, .changes kept, requires `--dev --image PATH`

--- a/openai_tools.py
+++ b/openai_tools.py
@@ -49,17 +49,22 @@ OPENAI_TOOLS = [
         "type": "function",
         "function": {
             "name": "smalltalk_method_source",
-            "description": "Get the source code of a specific method.",
+            "description": "Get the source code of a specific method. Supports class-side methods via the side parameter or 'ClassName class' syntax in className.",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "className": {
                         "type": "string",
-                        "description": "Name of the class"
+                        "description": "Name of the class (use 'ClassName class' for class-side methods)"
                     },
                     "selector": {
                         "type": "string",
                         "description": "Method selector"
+                    },
+                    "side": {
+                        "type": "string",
+                        "enum": ["instance", "class"],
+                        "description": "Which side of the class to look up (default: instance)"
                     }
                 },
                 "required": ["className", "selector"]


### PR DESCRIPTION
## Summary

Syncs private Bitbucket development (PRs #8-#10) to the public GitHub repo. MCPServer v5 → v7.

## What's New

### MCPServer v7 (MCP-Server-Squeak.st)
- **v6:** Fix `getenv:` for Squeak (was Cuis-only method — added OSProcess fallback)
- **v7:** Class-side method support:
  - `toolMethodSource:` accepts `side` param (`instance`/`class`) and `ClassName class` syntax
  - `toolBrowse:` returns `classMethods` array alongside instance `methods`
  - Decompilation fallback when .changes file unavailable (playground mode)
  - Handles comment read errors gracefully

### Clawdbot Skill Updates
- **method-source:** `--class-side` flag and `"ClassName class"` syntax
- **LLM-powered tools** (JMM-510/511): `explain`, `explain-method`, `audit-comment`, `audit-class` — all with class-side support
- **Daemon:** env-var driven, playground mode, version verification

### New Files (JMM-512)
- `clawdbot/smalltalk-dev-daemon.py` — Dev mode daemon (preserves .changes)
- `clawdbot/smalltalk_projects.py` — Project/snapshot management
- `clawdbot/st` — Unified CLI wrapper

### OpenAI Bridge
- `openai_tools.py` — Added `side` param to `smalltalk_method_source`

### Documentation
All docs updated for v7: CLAWDBOT-SETUP.md, SQUEAK-SETUP.md, OPENAI-SETUP.md, SKILL.md, README.md

## Testing
22/22 tool tests pass (JMM-516). Full test suite covers all 14 MCP tools plus v7 class-side features and LLM tools.

## Files Changed
- 13 files: 1,891 insertions, 222 deletions
- 3 new files added

## Not Included (private only)
CLAUDE.md, InternalSecurityNotes.txt, .mcp.json, MQTT5 packages, debug tools, planning notes