### PR TITLE
Fix code review issues: smart quotes, version sync, class-side schema, imports

### DIFF
--- a/OPENAI-SETUP.md
+++ b/OPENAI-SETUP.md
@@ -15,7 +15,7 @@ The Python bridge:
 
 ## Prerequisites
 
-1. **Python 3.8+** (OpenAI SDK requirement)
+1. **Python 3.10+** (required for type hints and MCP SDK)
 2. **OpenAI API Key** - Get one from https://platform.openai.com/api-keys
 3. **Squeak 6.0** with MCP server - See SQUEAK-SETUP.md
 

--- a/claudeCuis_mcp.py
+++ b/claudeCuis_mcp.py
@@ -160,7 +160,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="smalltalk_method_source",
-            description="Get the source code of a specific method.",
+            description="Retrieve the source code of a specific method. Supports class-side methods via the side parameter.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -171,6 +171,11 @@ async def list_tools() -> list[Tool]:
                     "selector": {
                         "type": "string",
                         "description": "Method selector (e.g., 'at:put:')"
+                    },
+                    "side": {
+                        "type": "string",
+                        "enum": ["instance", "class"],
+                        "description": "Which side of the class to look up (default: instance)"
                     }
                 },
                 "required": ["className", "selector"]

--- a/claude_smalltalk/mcp_server.py
+++ b/claude_smalltalk/mcp_server.py
@@ -160,7 +160,7 @@ async def list_tools() -> list[Tool]:
         ),
         Tool(
             name="smalltalk_method_source",
-            description="Get the source code of a specific method.",
+            description="Retrieve the source code of a specific method. Supports class-side methods via the side parameter.",
             inputSchema={
                 "type": "object",
                 "properties": {
@@ -171,6 +171,11 @@ async def list_tools() -> list[Tool]:
                     "selector": {
                         "type": "string",
                         "description": "Method selector (e.g., 'at:put:')"
+                    },
+                    "side": {
+                        "type": "string",
+                        "enum": ["instance", "class"],
+                        "description": "Which side of the class to look up (default: instance)"
                     }
                 },
                 "required": ["className", "selector"]

--- a/claude_smalltalk/openai_mcp.py
+++ b/claude_smalltalk/openai_mcp.py
@@ -37,7 +37,10 @@ from typing import Optional
 
 from openai import OpenAI
 
-from openai_tools import OPENAI_TOOLS, FUNCTION_TO_MCP_TOOL
+try:
+    from .openai_tools import OPENAI_TOOLS, FUNCTION_TO_MCP_TOOL
+except ImportError:
+    from openai_tools import OPENAI_TOOLS, FUNCTION_TO_MCP_TOOL
 
 
 class MCPConnection:

--- a/mcp.json
+++ b/mcp.json
@@ -1,225 +1,256 @@
 {
-“name”: “claude-smalltalk”,
-“version”: “1.2.0”,
-“description”: “MCP server enabling Claude and OpenAI to interact with live Smalltalk images (Cuis and Squeak) for conversational programming—evaluate code, browse classes, define methods, and navigate the system”,
-“author”: “Corporate Smalltalk Consulting Ltd”,
-“license”: “MIT”,
-“repository”: “https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk”,
-“homepage”: “https://www.smalltalkconsulting.com/”,
-“tools”: [
-{
-“name”: “smalltalk_evaluate”,
-“description”: “Execute arbitrary Smalltalk code and return the result”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“code”: {
-“type”: “string”,
-“description”: “Smalltalk expression to evaluate”
-}
-},
-“required”: [“code”]
-}
-},
-{
-“name”: “smalltalk_browse”,
-“description”: “Get class metadata including superclass, instance variables, and method selectors”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class to browse”
-}
-},
-“required”: [“className”]
-}
-},
-{
-“name”: “smalltalk_method_source”,
-“description”: “Retrieve the source code of a specific method”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class containing the method”
-},
-“selector”: {
-“type”: “string”,
-“description”: “Method selector (e.g., ‘at:ifAbsent:’)”
-}
-},
-“required”: [“className”, “selector”]
-}
-},
-{
-“name”: “smalltalk_define_class”,
-“description”: “Create or modify a class using a full Smalltalk class definition expression”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“definition”: {
-“type”: “string”,
-“description”: “Complete Smalltalk class definition (e.g., ‘Object subclass: #MyClass instanceVariableNames: …’)”
-}
-},
-“required”: [“definition”]
-}
-},
-{
-“name”: “smalltalk_define_method”,
-“description”: “Add or update a method in a class”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class to add the method to”
-},
-“source”: {
-“type”: “string”,
-“description”: “Complete method source code including selector”
-}
-},
-“required”: [“className”, “source”]
-}
-},
-{
-“name”: “smalltalk_delete_method”,
-“description”: “Remove a method from a class”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class containing the method”
-},
-“selector”: {
-“type”: “string”,
-“description”: “Selector of the method to remove”
-}
-},
-“required”: [“className”, “selector”]
-}
-},
-{
-“name”: “smalltalk_delete_class”,
-“description”: “Remove a class from the system”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class to delete”
-}
-},
-“required”: [“className”]
-}
-},
-{
-“name”: “smalltalk_list_classes”,
-“description”: “List class names, optionally filtered by prefix”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“prefix”: {
-“type”: “string”,
-“description”: “Optional prefix to filter class names”
-}
-}
-}
-},
-{
-“name”: “smalltalk_hierarchy”,
-“description”: “Get the inheritance chain from a class up to ProtoObject”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class”
-}
-},
-“required”: [“className”]
-}
-},
-{
-“name”: “smalltalk_subclasses”,
-“description”: “Get the immediate subclasses of a class”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“className”: {
-“type”: “string”,
-“description”: “Name of the class”
-}
-},
-“required”: [“className”]
-}
-},
-{
-“name”: “smalltalk_list_categories”,
-“description”: “List all system categories”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {}
-}
-},
-{
-“name”: “smalltalk_classes_in_category”,
-“description”: “List all classes in a specific system category”,
-“inputSchema”: {
-“type”: “object”,
-“properties”: {
-“category”: {
-“type”: “string”,
-“description”: “Name of the category”
-}
-},
-“required”: [“category”]
-}
-}
-],
-“configuration”: {
-“transport”: “stdio”,
-“runtime”: “python”,
-“entrypoint”: “claudeCuis_mcp.py”,
-“env”: {
-“MQTT_BROKER”: {
-“description”: “MQTT broker hostname”,
-“default”: “localhost”
-},
-“MQTT_PORT”: {
-“description”: “MQTT broker port”,
-“default”: “1883”
-},
-“CLAUDE_IMAGE_ID”: {
-“description”: “Target Smalltalk image identifier for routing”,
-“default”: “dev1”
-},
-“CLAUDE_TIMEOUT”: {
-“description”: “Response timeout in seconds”,
-“default”: “30”
-}
-}
-},
-“keywords”: [
-“smalltalk”,
-“cuis”,
-“squeak”,
-“cuis-smalltalk”,
-“live-programming”,
-“ide”,
-“conversational-programming”,
-“development-tools”,
-“mqtt”,
-“openai”,
-“claude”,
-“mcp”
-],
-“categories”: [
-“Development Tools”,
-“Programming Languages”
-]
+  "name": "claude-smalltalk",
+  "version": "1.2.2",
+  "description": "MCP server enabling Claude and OpenAI to interact with live Smalltalk images (Cuis and Squeak) for conversational programming\u2014evaluate code, browse classes, define methods, and navigate the system",
+  "author": "Corporate Smalltalk Consulting Ltd",
+  "license": "MIT",
+  "repository": "https://github.com/CorporateSmalltalkConsultingLtd/ClaudeSmalltalk",
+  "homepage": "https://www.smalltalkconsulting.com/",
+  "tools": [
+    {
+      "name": "smalltalk_evaluate",
+      "description": "Execute arbitrary Smalltalk code and return the result",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Smalltalk expression to evaluate"
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_browse",
+      "description": "Get class metadata including superclass, instance variables, and method selectors",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class to browse"
+          }
+        },
+        "required": [
+          "className"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_method_source",
+      "description": "Retrieve the source code of a specific method. Supports class-side methods via the side parameter.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class containing the method"
+          },
+          "selector": {
+            "type": "string",
+            "description": "Method selector (e.g., 'at:ifAbsent:')"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "instance",
+              "class"
+            ],
+            "description": "Which side of the class to look up (default: instance)"
+          }
+        },
+        "required": [
+          "className",
+          "selector"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_define_class",
+      "description": "Create or modify a class using a full Smalltalk class definition expression",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "definition": {
+            "type": "string",
+            "description": "Complete Smalltalk class definition (e.g., 'Object subclass: #MyClass instanceVariableNames: \u2026')"
+          }
+        },
+        "required": [
+          "definition"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_define_method",
+      "description": "Add or update a method in a class",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class to add the method to"
+          },
+          "source": {
+            "type": "string",
+            "description": "Complete method source code including selector"
+          }
+        },
+        "required": [
+          "className",
+          "source"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_delete_method",
+      "description": "Remove a method from a class",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class containing the method"
+          },
+          "selector": {
+            "type": "string",
+            "description": "Selector of the method to remove"
+          }
+        },
+        "required": [
+          "className",
+          "selector"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_delete_class",
+      "description": "Remove a class from the system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class to delete"
+          }
+        },
+        "required": [
+          "className"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_list_classes",
+      "description": "List class names, optionally filtered by prefix",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "description": "Optional prefix to filter class names"
+          }
+        }
+      }
+    },
+    {
+      "name": "smalltalk_hierarchy",
+      "description": "Get the inheritance chain from a class up to ProtoObject",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class"
+          }
+        },
+        "required": [
+          "className"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_subclasses",
+      "description": "Get the immediate subclasses of a class",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "className": {
+            "type": "string",
+            "description": "Name of the class"
+          }
+        },
+        "required": [
+          "className"
+        ]
+      }
+    },
+    {
+      "name": "smalltalk_list_categories",
+      "description": "List all system categories",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "smalltalk_classes_in_category",
+      "description": "List all classes in a specific system category",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Name of the category"
+          }
+        },
+        "required": [
+          "category"
+        ]
+      }
+    }
+  ],
+  "configuration": {
+    "transport": "stdio",
+    "runtime": "python",
+    "entrypoint": "claudeCuis_mcp.py",
+    "env": {
+      "MQTT_BROKER": {
+        "description": "MQTT broker hostname",
+        "default": "localhost"
+      },
+      "MQTT_PORT": {
+        "description": "MQTT broker port",
+        "default": "1883"
+      },
+      "CLAUDE_IMAGE_ID": {
+        "description": "Target Smalltalk image identifier for routing",
+        "default": "dev1"
+      },
+      "CLAUDE_TIMEOUT": {
+        "description": "Response timeout in seconds",
+        "default": "30"
+      }
+    }
+  },
+  "keywords": [
+    "smalltalk",
+    "cuis",
+    "squeak",
+    "cuis-smalltalk",
+    "live-programming",
+    "ide",
+    "conversational-programming",
+    "development-tools",
+    "mqtt",
+    "openai",
+    "claude",
+    "mcp"
+  ],
+  "categories": [
+    "Development Tools",
+    "Programming Languages"
+  ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Python dependencies for ClaudeSmalltalk
 #
-# Option D (OpenAI Bridge) - works with Python 3.8+
+# Option D (OpenAI Bridge) - requires Python 3.10+
 openai>=1.0.0
 
 # Option A (Python/MQTT Bridge) - requires Python 3.10+


### PR DESCRIPTION
Addresses issues from external code review:

## Fixes

1. **mcp.json invalid JSON** — All quotes were Unicode smart quotes (`"` `"` `'` `'`), making `json.loads()` fail. Replaced with standard ASCII quotes and reformatted.

2. **Version number sync** — Four files had different versions (1.2.0, 1.2.1, 1.2.2). All now consistently 1.2.2:
   - `mcp.json`: 1.2.0 → 1.2.2
   - `server.json`: 1.2.1 → 1.2.2
   - `claude_smalltalk/__init__.py`: 1.2.1 → 1.2.2
   - `pyproject.toml`: already 1.2.2 ✓

3. **Class-side schema missing** — `smalltalk_method_source` now declares the optional `side` parameter (`enum: ["instance", "class"]`) in:
   - `mcp.json`
   - `claudeCuis_mcp.py`
   - `claude_smalltalk/mcp_server.py`
   
   This ensures MCP clients can discover class-side capability from the schema.

4. **Broken import in package** — `claude_smalltalk/openai_mcp.py` used bare `from openai_tools import ...` which fails when installed as a package. Now uses relative import with fallback.

5. **Python version inconsistency** — `OPENAI-SETUP.md` and `requirements.txt` claimed Python 3.8+, but `pyproject.toml` requires 3.10+ and code uses modern typing. Fixed docs to say 3.10+.

## Not addressed (already correct)

- **14 vs 12 tools**: Docs already correctly say 12 tools
- **clawdbot/st script**: Now exists after PR #25 merge