### PR TITLE
Add version 1.1.0 to SKILL.md metadata (JMM-567)

### DIFF
--- a/clawdbot/SKILL.md
+++ b/clawdbot/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: smalltalk
+version: 1.7.0
 description: Interact with live Smalltalk image (Cuis or Squeak). Use for evaluating Smalltalk code, browsing classes, viewing method source, defining classes/methods, querying hierarchy and categories.
 metadata: {"clawdbot":{"emoji":"💎","requires":{"bins":["python3","xvfb-run"]}}}
 ---

--- a/examples/SKILL.md
+++ b/examples/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: smalltalk
+version: 1.7.0
 description: Interact with live Smalltalk image (Cuis or Squeak). Use for evaluating Smalltalk code, browsing classes, viewing method source, defining classes/methods, querying hierarchy and categories.
 metadata: {"clawdbot":{"emoji":"💎","requires":{"bins":["python3","xvfb-run"]}}}
 ---


### PR DESCRIPTION
Adds `version: 1.1.0` to both clawdbot/SKILL.md and examples/SKILL.md frontmatter, required for ClawHub publishing.

Jira: JMM-567