### PR TITLE
Fix SetElement storage in SetWithNil

### DIFF
--- a/SetWithNil.st
+++ b/SetWithNil.st
@@ -1,0 +1,315 @@
+Object subclass: #SetElement
+  instanceVariableNames: 
+    ' wrappedObject '
+  classVariableNames: ''
+  poolDictionaries: '' !
+
+
+!SetElement class methods !
+
+comment
+
+"SetElement wraps an object for storage in a SetWithNil. This allows nil to be stored
+in hash-based collections that use nil as an empty-slot sentinel.
+
+Most objects return self from asSetElement. UndefinedObject (nil) returns a
+SetElement wrapping nil, so the Set can distinguish empty slots from stored nils.
+
+See also: SetWithNil, Object>>asSetElement, UndefinedObject>>asSetElement."
+
+    ! !
+
+
+!SetElement methods !
+
+= anObject 
+
+	"Answer true if the receiver equals anObject. Delegates to the wrapped object."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    anObject class == self class
+        ifTrue: [^wrappedObject = anObject wrappedObject]
+        ifFalse: [^wrappedObject = anObject]!
+
+enclosedElement 
+
+	"Answer the wrapped object. Used by SetWithNil to unwrap elements."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^wrappedObject!
+
+hash 
+
+	"Answer the hash of the wrapped object for consistent hashing."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^wrappedObject hash!
+
+printOn: aStream 
+
+	"Print a representation of the wrapped object."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    aStream nextPutAll: 'a SetElement('.
+    wrappedObject printOn: aStream.
+    aStream nextPut: $)!
+
+wrappedObject 
+
+	"Answer the object wrapped by this SetElement."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^wrappedObject!
+
+wrappedObject: anObject 
+
+	"Set the object wrapped by this SetElement."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    wrappedObject := anObject!
+
+asSetElement 
+
+	"Wrap self in another SetElement so SetWithNil can store SetElement instances correctly.
+	Without this override, a SetElement added to a SetWithNil would be unwrapped by
+	enclosedElement on retrieval, returning the wrappedObject instead of the SetElement."
+    #CodeTrackerBlock.  "Last Modified  18:15:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^SetElement new wrappedObject: self! !
+
+
+Set subclass: #SetWithNil
+  instanceVariableNames: 
+    ''
+  classVariableNames: ''
+  poolDictionaries: '' !
+
+
+!SetWithNil class methods !
+
+comment
+
+"SetWithNil is a Set that correctly handles nil as an element.
+
+Standard Set uses nil as an empty-slot sentinel in its hash bucket array, so
+add: nil is silently ignored, includes: nil always returns false, and adding nil
+multiple times creates duplicates.
+
+SetWithNil fixes this by wrapping nil in a SetElement via asSetElement before
+storing it, and unwrapping via enclosedElement when retrieving. Non-nil objects
+pass through unchanged (Object>>asSetElement returns self).
+
+Usage:
+  | s |
+  s := SetWithNil new.
+  s add: nil.
+  s includes: nil.    true
+  s add: nil.
+  s size.             1
+
+See also: SetElement, Object>>asSetElement, UndefinedObject>>asSetElement."
+
+    ! !
+
+
+!SetWithNil methods !
+
+add: element 
+
+	"Add element to the receiver. Wraps nil in a SetElement to avoid sentinel conflicts."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^(super add: element asSetElement) enclosedElement!
+
+do: aBlock 
+
+	"Evaluate aBlock for each element, unwrapping SetElements."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    super do: [:each | aBlock value: each enclosedElement]!
+
+includes: element 
+
+	"Answer true if the receiver contains element. Handles nil correctly."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^super includes: element asSetElement!
+
+occurrencesOf: element 
+
+	"Answer the number of occurrences of element. Handles nil correctly."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^super occurrencesOf: element asSetElement!
+
+remove: element ifAbsent: aBlock 
+
+	"Remove element from the receiver. Handles nil correctly."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^(super remove: element asSetElement ifAbsent: [^aBlock value]) enclosedElement! !
+
+
+"Extension methods on Object and UndefinedObject"
+
+
+!Object methods !
+
+asSetElement 
+
+	"Answer the receiver as a SetElement. Most objects return self."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^self!
+
+enclosedElement 
+
+	"Answer the receiver. Non-wrapped objects return self."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^self! !
+
+
+!UndefinedObject methods !
+
+asSetElement 
+
+	"Answer a SetElement wrapping nil so Sets can store nil without sentinel conflicts."
+    #CodeTrackerBlock.  "Last Modified  05:30:00 02/18/26"
+    #LabWare. "Owner"
+    #XBase. "Type"
+    #V8. "Project"
+    #V8. "Module"
+    #None. "Unit"
+    #JMM. "RevisedBy"
+    #NotReviewed. "ReviewedBy"
+    #JMMXXX. "LabTrackId"
+    #CodeTrackerBlockEnd.  "Copyright 2026 LabWare Inc."
+
+    ^SetElement new wrappedObject: self! !

--- a/SetWithNilTest.st
+++ b/SetWithNilTest.st
@@ -1,0 +1,141 @@
+TestCase subclass: #SetWithNilTest
+  instanceVariableNames: 
+    ''
+  classVariableNames: ''
+  poolDictionaries: '' !
+
+
+!SetWithNilTest methods !
+
+testAddNil 
+
+	"Verify SetWithNil can store and find nil."
+
+    | s |
+    s := SetWithNil new.
+    s add: nil.
+    self assert: (s includes: nil)!
+
+testAddNilOnce 
+
+	"Verify adding nil twice results in size 1."
+
+    | s |
+    s := SetWithNil new.
+    s add: nil.
+    s add: nil.
+    self assert: s size = 1!
+
+testAsSetElement 
+
+	"Verify asSetElement protocol: non-nil returns self, nil returns SetElement."
+
+    self assert: 42 asSetElement = 42.
+    self assert: nil asSetElement class = SetElement.
+    self assert: nil asSetElement enclosedElement isNil!
+
+testDoEnumeratesNil 
+
+	"Verify do: correctly enumerates nil elements."
+
+    | s r |
+    s := SetWithNil new.
+    s add: nil.
+    s add: 1.
+    s add: 2.
+    r := OrderedCollection new.
+    s do: [:e | r add: e].
+    self assert: r size = 3.
+    self assert: (r includes: nil)!
+
+testEmptySetWithNil 
+
+	"Verify empty SetWithNil behaves correctly."
+
+    | s |
+    s := SetWithNil new.
+    self assert: s size = 0.
+    self deny: (s includes: nil).
+    self assert: (s occurrencesOf: nil) = 0!
+
+testMixedElements 
+
+	"Verify SetWithNil works with nil and non-nil elements together."
+
+    | s |
+    s := SetWithNil new.
+    s add: nil.
+    s add: 42.
+    s add: 'hello'.
+    self assert: s size = 3.
+    self assert: (s includes: nil).
+    self assert: (s includes: 42).
+    self assert: (s includes: 'hello').
+    self deny: (s includes: 99)!
+
+testNonNilPassthrough 
+
+	"Verify non-nil elements work normally (no regressions)."
+
+    | s |
+    s := SetWithNil new.
+    s add: 1.
+    s add: 2.
+    s add: 3.
+    self assert: s size = 3.
+    self assert: (s includes: 2).
+    s remove: 2 ifAbsent: [self signalFailure: '2 not found'].
+    self assert: s size = 2.
+    self deny: (s includes: 2)!
+
+testOccurrencesOfNil 
+
+	"Verify occurrencesOf: works for nil."
+
+    | s |
+    s := SetWithNil new.
+    s add: nil.
+    self assert: (s occurrencesOf: nil) = 1.
+    self assert: (s occurrencesOf: 99) = 0!
+
+testRemoveNil 
+
+	"Verify nil can be removed from SetWithNil."
+
+    | s |
+    s := SetWithNil new.
+    s add: nil.
+    s add: 42.
+    s remove: nil ifAbsent: [self signalFailure: 'nil not found'].
+    self assert: s size = 1.
+    self deny: (s includes: nil).
+    self assert: (s includes: 42)!
+
+testSetCannotStoreNil 
+
+	"Confirm standard Set cannot store nil (documents the bug SetWithNil fixes)."
+
+    | s |
+    s := Set new.
+    s add: nil.
+    self deny: (s includes: nil)!
+
+testSetElementInSetWithNil 
+
+	"Verify that adding a SetElement instance to a SetWithNil stores and retrieves it correctly.
+	Without SetElement>>asSetElement, enclosedElement would unwrap it to wrappedObject."
+
+    | s elem result |
+    elem := SetElement new wrappedObject: 42.
+    s := SetWithNil new.
+    s add: elem.
+    self assert: s size = 1.
+    self assert: (s includes: elem).
+    self deny: (s includes: 42).
+    result := OrderedCollection new.
+    s do: [:e | result add: e].
+    self assert: result size = 1.
+    self assert: result first class = SetElement.
+    self assert: result first wrappedObject = 42.
+    s remove: elem ifAbsent: [self signalFailure: 'SetElement not found'].
+    self assert: s size = 0! !


### PR DESCRIPTION
## Problem

Adding a `SetElement` instance to a `SetWithNil` would silently lose the wrapper on retrieval. The `add:`, `do:`, `includes:`, and `remove:ifAbsent:` methods all call `enclosedElement`, which unwraps SetElement to its wrappedObject.

For example:
```smalltalk
| s elem |
elem := SetElement new wrappedObject: 42.
s := SetWithNil new.
s add: elem.
s do: [:e | e class].  "answered SmallInteger (42), not SetElement"
```

## Fix

Added `SetElement>>asSetElement` which wraps self in another SetElement (matching the pattern used by `UndefinedObject>>asSetElement`). On retrieval, `enclosedElement` peels off the outer wrapper and returns the original SetElement.

## Test

Added `testSetElementInSetWithNil` SUnit test verifying add, includes, do:, and remove all handle SetElement instances correctly.

Related: JMM-612